### PR TITLE
Double clicking GameObject looks at object

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/Outline.kt
@@ -225,11 +225,7 @@ class Outline : VisTable(),
                 if (tapCount != 2)
                     return
 
-                val node = tree.getNodeAt(y)
-                var go: GameObject? = null
-                if (node != null) {
-                    go = node.value
-                }
+                val go = tree.getNodeAt(y)?.value
 
                 if (go != null) {
                     val context = projectManager.current()
@@ -238,7 +234,7 @@ class Outline : VisTable(),
 
                     // just lerp in the direction of the object if certain distance away
                     if (pos.dst(context.currScene.cam.position) > 100)
-                        context.currScene.cam.position.lerp(pos.cpy().add(0f,20f,0f), 0.5f)
+                        context.currScene.cam.position.lerp(pos.cpy().add(0f,40f,0f), 0.5f)
 
                     context.currScene.cam.lookAt(pos)
                     context.currScene.cam.up.set(Vector3.Y)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/Outline.kt
@@ -220,10 +220,43 @@ class Outline : VisTable(),
 
         })
 
-        // right click menu listener
-        tree.addListener(object : InputListener() {
+        tree.addListener(object : ClickListener() {
+            override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                if (tapCount != 2)
+                    return
+
+                val node = tree.getNodeAt(y)
+                var go: GameObject? = null
+                if (node != null) {
+                    go = node.value
+                }
+
+                if (go != null) {
+                    val context = projectManager.current()
+                    val pos = Vector3()
+                    go.transform.getTranslation(pos)
+
+                    // just lerp in the direction of the object if certain distance away
+                    if (pos.dst(context.currScene.cam.position) > 100)
+                        context.currScene.cam.position.lerp(pos.cpy().add(0f,20f,0f), 0.5f)
+
+                    context.currScene.cam.lookAt(pos)
+                    context.currScene.cam.up.set(Vector3.Y)
+                }
+
+            }
+
+            override fun touchDown(event: InputEvent?, x: Float, y: Float, pointer: Int, button: Int): Boolean {
+                if (Input.Buttons.LEFT != button) {
+                    return true
+                }
+                return super.touchDown(event, x, y, pointer, button)
+            }
+
+            // right click menu listener
             override fun touchUp(event: InputEvent?, x: Float, y: Float, pointer: Int, button: Int) {
                 if (Input.Buttons.RIGHT != button) {
+                    super.touchUp(event, x, y, pointer, button)
                     return
                 }
 
@@ -235,9 +268,6 @@ class Outline : VisTable(),
                 rightClickMenu.show(go, Gdx.input.x.toFloat(), (Gdx.graphics.height - Gdx.input.y).toFloat())
             }
 
-            override fun touchDown(event: InputEvent?, x: Float, y: Float, pointer: Int, button: Int): Boolean {
-                return true
-            }
         })
 
         // select listener


### PR DESCRIPTION
Adds a double click action on game objects within the scene tree. When double (left) clicked the camera will look at that object. If its more than a certain distance away camera will do a basic lerp towards the target as well. Functionality is limited for now but may make it smarter about object size down the line.


![doubleclick](https://user-images.githubusercontent.com/28971753/163699622-08460fec-873e-4357-b079-04fd666a4efc.gif)

