### PR TITLE
Add editable uv scale for terrains

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
@@ -16,6 +16,7 @@
 package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.FloatArray;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
 import com.mbrlabs.mundus.commons.terrain.SplatMap;
@@ -160,6 +161,7 @@ public class TerrainAsset extends Asset {
 
         terrain = new Terrain(meta.getTerrain().getSize(), data);
         terrain.init();
+        terrain.updateUvScale(new Vector2(meta.getTerrain().getUv(), meta.getTerrain().getUv()));
         terrain.update();
     }
 
@@ -243,5 +245,11 @@ public class TerrainAsset extends Asset {
     @Override
     public void dispose() {
 
+    }
+
+    public void updateUvScale(Vector2 uvScale) {
+        terrain.updateUvScale(uvScale);
+        terrain.update();
+        meta.getTerrain().setUv(uvScale.x);
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import com.mbrlabs.mundus.commons.assets.AssetType;
+import com.mbrlabs.mundus.commons.terrain.Terrain;
 
 /**
  *
@@ -57,7 +58,7 @@ public class MetaLoader {
 
         final MetaTerrain terrain = new MetaTerrain();
         terrain.setSize(jsonTerrain.getInt(MetaTerrain.JSON_SIZE));
-        terrain.setUv(jsonTerrain.getFloat(MetaTerrain.JSON_UV_SCALE, 60));
+        terrain.setUv(jsonTerrain.getFloat(MetaTerrain.JSON_UV_SCALE, Terrain.DEFAULT_UV_SCALE));
         terrain.setSplatmap(jsonTerrain.getString(MetaTerrain.JSON_SPLATMAP, null));
         terrain.setSplatBase(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_BASE, null));
         terrain.setSplatR(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_R, null));

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -57,6 +57,7 @@ public class MetaLoader {
 
         final MetaTerrain terrain = new MetaTerrain();
         terrain.setSize(jsonTerrain.getInt(MetaTerrain.JSON_SIZE));
+        terrain.setUv(jsonTerrain.getFloat(MetaTerrain.JSON_UV_SCALE, 60));
         terrain.setSplatmap(jsonTerrain.getString(MetaTerrain.JSON_SPLATMAP, null));
         terrain.setSplatBase(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_BASE, null));
         terrain.setSplatR(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_R, null));

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaTerrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaTerrain.java
@@ -30,8 +30,10 @@ public class MetaTerrain {
     public static final String JSON_SPLAT_G = "g";
     public static final String JSON_SPLAT_B = "b";
     public static final String JSON_SPLAT_A = "a";
+    public static final String JSON_UV_SCALE= "uv";
 
     private int size;
+    private float uv;
     private String splatmap;
     private String splatBase;
     private String splatR;
@@ -95,6 +97,14 @@ public class MetaTerrain {
         this.size = size;
     }
 
+    public float getUv() {
+        return uv;
+    }
+
+    public void setUv(float uv) {
+        this.uv = uv;
+    }
+
     @Override
     public String toString() {
         return "MetaTerrain{" +
@@ -105,6 +115,7 @@ public class MetaTerrain {
                 ", splatG='" + splatG + '\'' +
                 ", splatB='" + splatB + '\'' +
                 ", splatA='" + splatA + '\'' +
+                ", uv='" + uv + '\'' +
                 '}';
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.commons.scene3d.components;
 
 import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.math.Vector2;
 import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 
@@ -35,6 +36,10 @@ public class TerrainComponent extends AbstractComponent {
         super(go);
         this.shader = shader;
         type = Component.Type.TERRAIN;
+    }
+
+    public void updateUVs(Vector2 uvScale) {
+        terrain.updateUvScale(uvScale);
     }
 
     public void setTerrain(TerrainAsset terrain) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -45,6 +45,7 @@ public class Terrain implements RenderableProvider, Disposable {
 
     public static final int DEFAULT_SIZE = 1600;
     public static final int DEFAULT_VERTEX_RESOLUTION = 180;
+    public static final int DEFAULT_UV_SCALE = 60;
 
     private static final MeshPartBuilder.VertexInfo tempVertexInfo = new MeshPartBuilder.VertexInfo();
     private static final Vector3 c00 = new Vector3();
@@ -60,7 +61,7 @@ public class Terrain implements RenderableProvider, Disposable {
 
     // used for building the mesh
     private VertexAttributes attribs;
-    private Vector2 uvScale = new Vector2(60, 60);
+    private Vector2 uvScale = new Vector2(DEFAULT_UV_SCALE, DEFAULT_UV_SCALE);
     private float vertices[];
     private int stride;
     private int posPos;

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -60,7 +60,7 @@ public class Terrain implements RenderableProvider, Disposable {
 
     // used for building the mesh
     private VertexAttributes attribs;
-    private final Vector2 uvScale = new Vector2(60, 60);
+    private Vector2 uvScale = new Vector2(60, 60);
     private float vertices[];
     private int stride;
     private int posPos;
@@ -243,6 +243,14 @@ public class Terrain implements RenderableProvider, Disposable {
         out.uv.set(dx, dz).scl(uvScale);
 
         return out;
+    }
+
+    public void updateUvScale(Vector2 uvScale) {
+        this.uvScale = uvScale;
+    }
+
+    public Vector2 getUvScale() {
+        return uvScale;
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -170,6 +170,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         val meta = createNewMetaFile(FileHandle(metaPath), AssetType.TERRAIN)
         meta.terrain = MetaTerrain()
         meta.terrain.size = size
+        meta.terrain.uv = 60f
         metaSaver.save(meta)
 
         // create terra file

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
@@ -73,6 +73,7 @@ class MetaSaver {
 
         json.writeObjectStart(Meta.JSON_TERRAIN)
         json.writeValue(MetaTerrain.JSON_SIZE, terrain.size)
+        json.writeValue(MetaTerrain.JSON_UV_SCALE, terrain.uv)
         if (terrain.splatmap != null) json.writeValue(MetaTerrain.JSON_SPLATMAP, terrain.splatmap)
         if (terrain.splatBase != null) json.writeValue(MetaTerrain.JSON_SPLAT_BASE, terrain.splatBase)
         if (terrain.splatR != null) json.writeValue(MetaTerrain.JSON_SPLAT_R, terrain.splatR)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainComponentWidget.kt
@@ -39,7 +39,7 @@ class TerrainComponentWidget(terrainComponent: TerrainComponent) :
     private val flattenTab = TerrainFlattenTab(this)
     private val paintTab = TerrainPaintTab(this)
     private val genTab = TerrainGenTab(this)
-    private val settingsTab = TerrainSettingsTab()
+    private val settingsTab = TerrainSettingsTab(this)
 
     init {
         tabbedPane.addListener(this)

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSettingsTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainSettingsTab.kt
@@ -16,23 +16,43 @@
 
 package com.mbrlabs.mundus.editor.ui.modules.inspector.components.terrain
 
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.ui.Table
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.tabbedpane.Tab
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.ui.widgets.ImprovedSlider
 
 /**
  * @author Marcus Brummer
  * @version 30-01-2016
  */
-class TerrainSettingsTab : Tab(false, false) {
+class TerrainSettingsTab(private val parentWidget: TerrainComponentWidget) : Tab(false, false) {
 
     private val table = VisTable()
+    private val uvSlider = ImprovedSlider(.5f, 120f, .5f)
+
+    private val projectManager: ProjectManager = Mundus.inject()
 
     init {
         table.align(Align.left)
-        table.add(VisLabel("Settings"))
+        table.add(VisLabel("Settings")).row()
+
+        table.add(VisLabel("UV scale")).left().row()
+        uvSlider.value = parentWidget.component.terrain.terrain.uvScale.x
+        table.add(uvSlider).expandX().fillX().row()
+        uvSlider.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent, actor: Actor) {
+                val assetManager = projectManager.current().assetManager
+                assetManager.addDirtyAsset(parentWidget.component.terrain)
+                parentWidget.component.updateUVs(Vector2(uvSlider.value, uvSlider.value))
+            }
+        })
     }
 
     override fun getTabTitle(): String {


### PR DESCRIPTION
Add UV scale slider in the terrain settings tab that persists and is stored in MetaTerrain

https://user-images.githubusercontent.com/28971753/164090477-356712c9-e8f1-4d20-8d40-4a3a688c53c1.mp4