### PR TITLE
Updated gltf version to 2.0.0-rc.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
         commonsIoVersion = '2.5'
         commonsLangVersion = '3.12.0'
         guacamoleVersion = '0.3.1'
-        gltfVersion = 'master-SNAPSHOT'
+        gltfVersion = '2.0.0-rc.1'
 
         ktxVersion = '1.10.0-b2'
     }


### PR DESCRIPTION
When I added the gltf library then there was not 2.x version but the 1.0.0 was a bit old. So I think better to use stable version instead of snapshot version.