### PR TITLE
Fix specular water

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.JsonValue;
 import com.mbrlabs.mundus.commons.assets.AssetType;
 import com.mbrlabs.mundus.commons.terrain.Terrain;
+import com.mbrlabs.mundus.commons.water.Water;
 
 /**
  *
@@ -81,6 +82,8 @@ public class MetaLoader {
         water.setTiling(jsonValue.getFloat(MetaWater.JSON_TILING));
         water.setWaveStrength(jsonValue.getFloat(MetaWater.JSON_WAVE_STRENGTH));
         water.setWaveSpeed(jsonValue.getFloat(MetaWater.JSON_WAVE_SPEED));
+        water.setReflectivity(readWithDefault(jsonValue, MetaWater.JSON_REFLECTIVITY, Water.DEFAULT_REFLECTIVITY));
+        water.setShineDamper(readWithDefault(jsonValue, MetaWater.JSON_SHINE_DAMPER, Water.DEFAULT_SHINE_DAMPER));
 
         meta.setWater(water);
     }
@@ -99,6 +102,27 @@ public class MetaLoader {
         }
 
         meta.setModel(model);
+    }
+
+    /**
+     * When new values are added and cannot be found on jsonValue.getXXX(),
+     * an IllegalArgumentException is thrown.
+     *
+     * To try and maintain backwards compatibility between meta changes,
+     * if we have a default value, that can be used with this method to
+     * default to it when it could not be found in the meta during parsing.
+     *
+     * @param jsonValue the JsonValue instance
+     * @param jsonKey the jsonKey value to try and read
+     * @param defaultValue the value to default to if jsonKey not found
+     * @return float from meta file, or default if not found
+     */
+    private float readWithDefault(JsonValue jsonValue, String jsonKey, float defaultValue) {
+        try {
+            return jsonValue.getFloat(jsonKey);
+        } catch (IllegalArgumentException ex) {
+            return defaultValue;
+        }
     }
 
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaWater.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaWater.java
@@ -7,11 +7,15 @@ public class MetaWater {
     public static final String JSON_TILING = "tiling";
     public static final String JSON_WAVE_STRENGTH = "waveStrength";
     public static final String JSON_WAVE_SPEED = "waveSpeed";
+    public static final String JSON_REFLECTIVITY = "reflectivity";
+    public static final String JSON_SHINE_DAMPER = "shineDamper";
 
     private int size;
     private float tiling;
     private float waveStrength;
     private float waveSpeed;
+    private float reflectivity;
+    private float shineDamper;
     private String dudvMap;
     private String normalMap;
 
@@ -63,6 +67,22 @@ public class MetaWater {
         this.waveSpeed = waveSpeed;
     }
 
+    public float getReflectivity() {
+        return reflectivity;
+    }
+
+    public void setReflectivity(float reflectivity) {
+        this.reflectivity = reflectivity;
+    }
+
+    public float getShineDamper() {
+        return shineDamper;
+    }
+
+    public void setShineDamper(float shineDamper) {
+        this.shineDamper = shineDamper;
+    }
+
     @Override
     public String toString() {
         return "MetaWater{" +
@@ -72,6 +92,8 @@ public class MetaWater {
                 ", tiling='" + tiling + '\'' +
                 ", waveStrength='" + waveStrength + '\'' +
                 ", waveSpeed='" + waveSpeed + '\'' +
+                ", reflectivity='" + reflectivity + '\'' +
+                ", shineDamper='" + shineDamper + '\'' +
                 '}';
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/WaterShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/WaterShader.java
@@ -88,8 +88,9 @@ public class WaterShader extends BaseShader {
         final Array<DirectionalLight> dirLights = dirLightAttribs == null ? null : dirLightAttribs.lights;
         if (dirLights != null && dirLights.size > 0) {
             final DirectionalLight light = dirLights.first();
-            set(UNIFORM_LIGHT_COLOR, Color.RED);
-            set(UNIFORM_LIGHT_POS, new Vector3(10f, 10f, 0f));
+            set(UNIFORM_LIGHT_COLOR, light.color.r, light.color.g, light.color.b);
+            // Normally this would be position but directional lights do not have a position
+            set(UNIFORM_LIGHT_POS, light.direction);
         }
 
         // Set Textures

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/WaterShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/WaterShader.java
@@ -25,16 +25,25 @@ public class WaterShader extends BaseShader {
     protected static final String VERTEX_SHADER = "com/mbrlabs/mundus/commons/shaders/water.vert.glsl";
     protected static final String FRAGMENT_SHADER = "com/mbrlabs/mundus/commons/shaders/water.frag.glsl";
 
+    // ============================ MATRICES & CAM POSITION ============================
     protected final int UNIFORM_PROJ_VIEW_MATRIX = register(new Uniform("u_projViewMatrix"));
     protected final int UNIFORM_TRANS_MATRIX = register(new Uniform("u_transMatrix"));
+    protected final int UNIFORM_CAM_POS = register(new Uniform("u_cameraPosition"));
+
+    // ============================ TEXTURES ============================
     protected final int UNIFORM_TEXTURE = register(new Uniform("u_texture"));
     public final int UNIFORM_REFRACTION_TEXTURE = register(new Uniform("u_refractionTexture"));
     protected final int UNIFORM_DUDV_TEXTURE = register(new Uniform("u_dudvTexture"));
     protected final int UNIFORM_NORMAL_MAP_TEXTURE = register(new Uniform("u_normalMapTexture"));
+
+    // ============================ FLOATS ============================
     protected final int UNIFORM_MOVE_FACTOR = register(new Uniform("u_moveFactor"));
     protected final int UNIFORM_TILING = register(new Uniform("u_tiling"));
     protected final int UNIFORM_WAVE_STRENGTH = register(new Uniform("u_waveStrength"));
-    protected final int UNIFORM_CAM_POS = register(new Uniform("u_cameraPosition"));
+    protected final int UNIFORM_SPECULAR_REFLECTIVITY = register(new Uniform("u_reflectivity"));
+    protected final int UNIFORM_SHINE_DAMPER = register(new Uniform("u_shineDamper"));
+
+    // ============================ LIGHTS ============================
     protected final int UNIFORM_LIGHT_POS = register(new Uniform("u_lightPositon"));
     protected final int UNIFORM_LIGHT_COLOR = register(new Uniform("u_lightColor"));
 
@@ -132,6 +141,20 @@ public class WaterShader extends BaseShader {
         WaterFloatAttribute speed = (WaterFloatAttribute) renderable.material.get(WaterFloatAttribute.WaveSpeed);
         if (speed != null) {
             waveSpeed = speed.value;
+        }
+
+        WaterFloatAttribute reflect = (WaterFloatAttribute) renderable.material.get(WaterFloatAttribute.Reflectivity);
+        if (reflect != null) {
+            set(UNIFORM_SPECULAR_REFLECTIVITY, reflect.value);
+        } else {
+            set(UNIFORM_SPECULAR_REFLECTIVITY, Water.DEFAULT_REFLECTIVITY);
+        }
+
+        WaterFloatAttribute shine = (WaterFloatAttribute) renderable.material.get(WaterFloatAttribute.ShineDamper);
+        if (shine != null) {
+            set(UNIFORM_SHINE_DAMPER, shine.value);
+        } else {
+            set(UNIFORM_SHINE_DAMPER, Water.DEFAULT_SHINE_DAMPER);
         }
 
         moveFactor +=  waveSpeed * Gdx.graphics.getDeltaTime();

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/water.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/water.frag.glsl
@@ -8,7 +8,6 @@ varying vec3 v_toCameraVector;
 varying vec3 v_fromLightVector;
 
 uniform vec3 u_color;
-uniform float u_alpha;
 uniform sampler2D u_texture;
 uniform sampler2D u_refractionTexture;
 uniform sampler2D u_dudvTexture;
@@ -16,10 +15,10 @@ uniform sampler2D u_normalMapTexture;
 uniform float u_waveStrength;
 uniform vec3 u_lightColor;
 uniform float u_moveFactor;
+uniform float u_shineDamper;
+uniform float u_reflectivity;
 
 const vec4 COLOR_TURQUOISE = vec4(0,0.5,0.686, 0.2);
-const float shineDamper = 20.0;
-const float reflectivity = 0.6;
 
 void main() {
 
@@ -60,8 +59,8 @@ void main() {
     // Calculate specular hightlights
     vec3 reflectedLight = reflect(normalize(v_fromLightVector), normal);
     float specular = max(dot(reflectedLight, viewVector), 0.0);
-    specular = pow(specular, shineDamper);
-    vec3 specularHighlights = u_lightColor * specular * reflectivity;
+    specular = pow(specular, u_shineDamper);
+    vec3 specularHighlights = u_lightColor * specular * u_reflectivity;
 
     vec4 color =  mix(reflectColor, refractColor, refractiveFactor);
     color = mix(color, COLOR_TURQUOISE, 0.2) + vec4(specularHighlights, 0.0);

--- a/commons/src/main/com/mbrlabs/mundus/commons/water/Water.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/water/Water.java
@@ -1,11 +1,9 @@
 package com.mbrlabs.mundus.commons.water;
 
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.*;
-import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
 import com.badlogic.gdx.math.Matrix4;

--- a/commons/src/main/com/mbrlabs/mundus/commons/water/Water.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/water/Water.java
@@ -19,6 +19,10 @@ public class Water implements RenderableProvider, Disposable {
     public static final float DEFAULT_TILING = 0.04f;
     public static final float DEFAULT_WAVE_STRENGTH = 0.04f;
     public static final float DEFAULT_WAVE_SPEED = 0.03f;
+    public static final float DEFAULT_REFLECTIVITY = 0.6f;
+    public static final float DEFAULT_SHINE_DAMPER = 20.0f;
+    private static final String materialId = "waterMat";
+
 
     public Matrix4 transform;
     public int waterWidth;
@@ -31,9 +35,6 @@ public class Water implements RenderableProvider, Disposable {
     // Mesh
     private Model model;
     public ModelInstance modelInstance;
-    public Mesh mesh;
-
-    private final String materialId = "waterMat";
 
     public Water(int size) {
         this.waterWidth = size;
@@ -64,6 +65,8 @@ public class Water implements RenderableProvider, Disposable {
         setTiling(DEFAULT_TILING);
         setWaveStrength(DEFAULT_WAVE_STRENGTH);
         setWaveSpeed(DEFAULT_WAVE_SPEED);
+        setReflectivity(DEFAULT_REFLECTIVITY);
+        setShineDamper(DEFAULT_SHINE_DAMPER);
     }
 
     @Override
@@ -115,6 +118,22 @@ public class Water implements RenderableProvider, Disposable {
 
     public float getWaveSpeed() {
         return material.get(WaterFloatAttribute.class, WaterFloatAttribute.WaveSpeed).value;
+    }
+
+    public void setReflectivity(float reflectivity) {
+        material.set(new WaterFloatAttribute(WaterFloatAttribute.Reflectivity, reflectivity));
+    }
+
+    public float getReflectivity() {
+        return material.get(WaterFloatAttribute.class, WaterFloatAttribute.Reflectivity).value;
+    }
+
+    public void setShineDamper(float shineDamper) {
+        material.set(new WaterFloatAttribute(WaterFloatAttribute.ShineDamper, shineDamper));
+    }
+
+    public float getShineDamper() {
+        return material.get(WaterFloatAttribute.class, WaterFloatAttribute.ShineDamper).value;
     }
 
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/water/WaterFloatAttribute.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/water/WaterFloatAttribute.java
@@ -12,6 +12,12 @@ public class WaterFloatAttribute extends FloatAttribute {
     public static final String WaveSpeedAlias = "waveSpeed";
     public static final long WaveSpeed = register(WaveSpeedAlias);
 
+    public static final String ReflectivityAlias = "reflectivity";
+    public static final long Reflectivity = register(ReflectivityAlias);
+
+    public static final String ShineDamperAlias = "shineDamper";
+    public static final long ShineDamper = register(ShineDamperAlias);
+
     public WaterFloatAttribute(long type) {
         super(type);
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
@@ -97,6 +97,8 @@ class MetaSaver {
         json.writeValue(MetaWater.JSON_TILING, water.tiling)
         json.writeValue(MetaWater.JSON_WAVE_STRENGTH, water.waveStrength)
         json.writeValue(MetaWater.JSON_WAVE_SPEED, water.waveSpeed)
+        json.writeValue(MetaWater.JSON_REFLECTIVITY, water.reflectivity)
+        json.writeValue(MetaWater.JSON_SHINE_DAMPER, water.shineDamper)
 
         json.writeObjectEnd()
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/WaterWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/WaterWidget.kt
@@ -25,6 +25,8 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
     private val tilingField = VisTextField()
     private val waveStrength = VisTextField()
     private val waveSpeed = VisTextField()
+    private val reflectivity = VisTextField()
+    private val shineDamper = VisTextField()
 
     private lateinit var selectBox: VisSelectBox<String>
 
@@ -53,6 +55,12 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
 
         add(VisLabel("Wave Speed:")).growX().row()
         add(waveSpeed).growX().row()
+
+        add(VisLabel("Reflectivity:")).growX().row()
+        add(reflectivity).growX().row()
+
+        add(VisLabel("Shine Damper:")).growX().row()
+        add(shineDamper).growX().row()
 
         val selectorsTable = VisTable(true)
         selectBox = VisSelectBox<String>()
@@ -114,6 +122,36 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
             }
         })
 
+        // reflectivity
+        reflectivity.textFieldFilter = FloatDigitsOnlyFilter(false)
+        reflectivity.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                if (reflectivity.isInputValid && !reflectivity.isEmpty) {
+                    try {
+                        waterComponent.waterAsset.water.reflectivity = reflectivity.text.toFloat()
+                        projectManager.current().assetManager.addDirtyAsset(waterComponent.waterAsset)
+                    } catch (ex : NumberFormatException) {
+                        Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing water reflectivity"))
+                    }
+                }
+            }
+        })
+
+        // shine damper
+        shineDamper.textFieldFilter = FloatDigitsOnlyFilter(false)
+        shineDamper.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent?, actor: Actor?) {
+                if (shineDamper.isInputValid && !shineDamper.isEmpty) {
+                    try {
+                        waterComponent.waterAsset.water.shineDamper = shineDamper.text.toFloat()
+                        projectManager.current().assetManager.addDirtyAsset(waterComponent.waterAsset)
+                    } catch (ex : NumberFormatException) {
+                        Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing water shine damper"))
+                    }
+                }
+            }
+        })
+
         // resolution
         selectBox.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
@@ -127,6 +165,8 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
                 waterComponent.waterAsset.water.tiling = Water.DEFAULT_TILING
                 waterComponent.waterAsset.water.waveStrength = Water.DEFAULT_WAVE_STRENGTH
                 waterComponent.waterAsset.water.waveSpeed = Water.DEFAULT_WAVE_SPEED
+                waterComponent.waterAsset.water.reflectivity = Water.DEFAULT_REFLECTIVITY
+                waterComponent.waterAsset.water.shineDamper = Water.DEFAULT_SHINE_DAMPER
                 projectManager.current().currScene.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION
                 projectManager.current().assetManager.addDirtyAsset(waterComponent.waterAsset)
 
@@ -142,6 +182,8 @@ class WaterWidget(val waterComponent: WaterComponent) : VisTable() {
         tilingField.text = waterComponent.waterAsset.water.tiling.toString()
         waveStrength.text = waterComponent.waterAsset.water.waveStrength.toString()
         waveSpeed.text = waterComponent.waterAsset.water.waveSpeed.toString()
+        reflectivity.text = waterComponent.waterAsset.water.reflectivity.toString()
+        shineDamper.text = waterComponent.waterAsset.water.shineDamper.toString()
         selectBox.selected = projectManager.current().currScene.waterResolution.value
     }
 }


### PR DESCRIPTION
Specular highlight code for water was in place but it was not working. This PR fixes specular highlight for water, and makes reflectivity and shine damper attributes editable on water components.

https://user-images.githubusercontent.com/28971753/167267431-421854dc-8cac-440f-8146-df35e53aa451.mp4


