### PR TITLE
Runtime 0.3.0 and change log updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Below are some of the more interesting features, that already work
 - 4 different brushes (brush form can be an arbitrary image, like in Blender or Gimp)
 - 3 brush modes for each brush: Raise/Lower, Flatten & texture paint
 - Water quads with reflections, refractions and customizable ripples
-- A skybox (not exportable yet)
+- Static Skyboxes with support for multiple skyboxes
 - Loading of g3db/gltf/glb files
 - Loading of obj/fbx/dae files (note, that the [fbx-conv](https://github.com/libgdx/fbx-conv) binary must be set in the settings)
 - Visual translation, rotation tool, and scaling tools 

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -22,11 +22,13 @@ import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
+import com.mbrlabs.mundus.commons.assets.SkyboxAsset;
 import com.mbrlabs.mundus.commons.assets.TerrainAsset;
 import com.mbrlabs.mundus.commons.env.MundusEnvironment;
 import com.mbrlabs.mundus.commons.env.lights.DirectionalLight;
@@ -72,7 +74,7 @@ public class Scene implements Disposable {
     public Scene() {
         environment = new MundusEnvironment();
         currentSelection = null;
-        terrains = new Array<TerrainAsset>();
+        terrains = new Array<>();
 
         cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         cam.position.set(0, 1, -3);
@@ -192,10 +194,34 @@ public class Scene implements Disposable {
         this.id = id;
     }
 
+    /**
+     * Set the water resolution to use for water reflection and refractions.
+     * This will reinitialize the frame buffers with the given resolution.
+     * @param resolution the resolution to use
+     */
     public void setWaterResolution(WaterResolution resolution) {
         this.waterResolution = resolution;
         Vector2 res = waterResolution.getResolutionValues();
         initFrameBuffers((int) res.x, (int) res.y);
+    }
+
+    /**
+     * Sets and switches the scenes skybox to the given SkyboxAsset.
+     *
+     * @param skyboxAsset the asset to use
+     * @param skyboxShader the shader to use
+     */
+    public void setSkybox(SkyboxAsset skyboxAsset, Shader skyboxShader) {
+        if (skyboxAsset == null) return;
+
+        skyboxAssetId = skyboxAsset.getID();
+        skybox =  new Skybox(skyboxAsset.positiveX.getFile(),
+                skyboxAsset.negativeX.getFile(),
+                skyboxAsset.positiveY.getFile(),
+                skyboxAsset.negativeY.getFile(),
+                skyboxAsset.positiveZ.getFile(),
+                skyboxAsset.negativeZ.getFile(),
+                skyboxShader);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -47,7 +47,7 @@ public class SceneGraph {
 
     public void render(float delta, Vector3 clippingPlane, float clipHeight) {
         for (GameObject go : root.getChildren()) {
-            if (go.name.contains("Water"))
+            if (go.findComponentByType(Component.Type.WATER) != null)
                 continue;
             go.render(delta, clippingPlane, clipHeight);
         }
@@ -56,7 +56,7 @@ public class SceneGraph {
     //todo consider using renderable sorter instead
     public void renderWater(float delta, Texture reflectionTexture, Texture refraction) {
         for (GameObject go : root.getChildren()) {
-            if (go.name.contains("Water")) {
+            if (go.findComponentByType(Component.Type.WATER) != null) {
                 WaterComponent waterComponent = (WaterComponent) go.findComponentByType(Component.Type.WATER);
                 if (waterComponent != null) {
                     waterComponent.getWaterAsset().setWaterReflectionTexture(reflectionTexture);

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -56,12 +56,10 @@ public class SceneGraph {
     //todo consider using renderable sorter instead
     public void renderWater(float delta, Texture reflectionTexture, Texture refraction) {
         for (GameObject go : root.getChildren()) {
-            if (go.findComponentByType(Component.Type.WATER) != null) {
-                WaterComponent waterComponent = (WaterComponent) go.findComponentByType(Component.Type.WATER);
-                if (waterComponent != null) {
-                    waterComponent.getWaterAsset().setWaterReflectionTexture(reflectionTexture);
-                    waterComponent.getWaterAsset().setWaterRefractionTexture(refraction);
-                }
+            WaterComponent waterComponent = (WaterComponent) go.findComponentByType(Component.Type.WATER);
+            if (waterComponent != null) {
+                waterComponent.getWaterAsset().setWaterReflectionTexture(reflectionTexture);
+                waterComponent.getWaterAsset().setWaterRefractionTexture(refraction);
                 go.render(delta);
             }
         }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -1,11 +1,12 @@
-[0.3.0]
-- Added GLB support
-- Added Water Components
+[0.3.0] ~ 11/05/2022
+- Added GLB support, PR #21
+- Added Water Components, PR #24
 - Added Full Screen preview (F8) and a toolbar icon
-- Added asset deletion functionality
+- Added asset deletion functionality, PR #2
 - Added double click on game object to focus camera on it
 - Added mouse scroll wheel zoom
 - Added a Log bar and dock to bottom of editor
+- Added SkyboxAsset and completed static Skybox feature, PR #33
 - Updated terrains for modifiable UV scale
 - Fixed NPE crash on GLTF model loading
 - Fixed rotation of models on import preview

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -18,7 +18,6 @@ package com.mbrlabs.mundus.editor.core.project;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
@@ -391,7 +390,7 @@ public class ProjectManager implements Disposable {
         // load skybox
         if (scene.skyboxAssetId != null && context.assetManager.getAssetMap().containsKey(scene.skyboxAssetId)) {
             SkyboxAsset asset = (SkyboxAsset) context.assetManager.getAssetMap().get(scene.skyboxAssetId);
-            scene.skybox = SkyboxBuilder.createSkyboxFromAsset(asset, Shaders.INSTANCE.getSkyboxShader());
+            scene.setSkybox(asset, Shaders.INSTANCE.getSkyboxShader());
         }
 
         scene.batch = modelBatch;

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
@@ -42,7 +42,6 @@ import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.shader.Shaders
 import com.mbrlabs.mundus.editor.ui.widgets.ImageChooserField
 import com.mbrlabs.mundus.editor.utils.createDefaultSkybox
-import com.mbrlabs.mundus.editor.utils.createSkyboxFromAsset
 
 /**
  * @author Marcus Brummer
@@ -141,8 +140,7 @@ class SkyboxDialog : BaseDialog("Skybox"), ProjectChangedEvent.ProjectChangedLis
             override fun changed(event: ChangeEvent?, actor: Actor?) {
                 projectContext.currScene.skybox?.dispose()
 
-                projectManager.current().currScene.skybox = createSkyboxFromAsset(selectBox.selected, Shaders.skyboxShader)
-                projectManager.current().currScene.skyboxAssetId = selectBox.selected.id
+                projectManager.current().currScene.setSkybox(selectBox.selected, Shaders.skyboxShader)
                 resetImages()
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/SkyboxBuilder.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/SkyboxBuilder.kt
@@ -20,7 +20,6 @@ package com.mbrlabs.mundus.editor.utils
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.g3d.Shader
-import com.mbrlabs.mundus.commons.assets.SkyboxAsset
 import com.mbrlabs.mundus.commons.skybox.Skybox
 
 fun createDefaultSkybox(shader : Shader): Skybox {
@@ -32,16 +31,6 @@ fun createDefaultSkybox(shader : Shader): Skybox {
 fun createNightSkybox(shader : Shader): Skybox {
     val texture = Gdx.files.internal("textures/skybox/star_night.png")
     return Skybox(texture, texture, texture, texture, texture, texture,
-            shader)
-}
-
-fun createSkyboxFromAsset(skyboxAsset: SkyboxAsset, shader: Shader): Skybox {
-    return Skybox(skyboxAsset.positiveX.file,
-            skyboxAsset.negativeX.file,
-            skyboxAsset.positiveY.file,
-            skyboxAsset.negativeY.file,
-            skyboxAsset.positiveZ.file,
-            skyboxAsset.negativeZ.file,
             shader)
 }
 

--- a/gdx-runtime/CHANGES
+++ b/gdx-runtime/CHANGES
@@ -1,3 +1,7 @@
+[0.3.0]
+- Enable fog in runtime
+- Skyboxes now supported in runtime via scene.setSkybox method
+
 [0.2.0]
 - Updated min java version to 1.7
 - Add Desktop support by handling loading of assets without using FileHandle.list();

--- a/gdx-runtime/build.gradle
+++ b/gdx-runtime/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "java"
 sourceSets.main.java.srcDirs = ["src/"]
 sourceSets.main.resources.srcDirs = ["src/"]
 
-def VERSION = '0.2.0'
+def VERSION = '0.3.0'
 def NAME = 'mundus-gdx-runtime'
 
 task distRuntime(type: Jar, dependsOn: classes) {

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/Shaders.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/Shaders.java
@@ -36,6 +36,7 @@ public class Shaders {
         waterShader = new WaterShader();
         waterShader.init();
         skyboxShader = new SkyboxShader();
+        skyboxShader.init();
     }
 
     public ModelShader getModelShader() {

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
@@ -20,7 +20,11 @@ import com.mbrlabs.mundus.commons.Scene;
 import com.mbrlabs.mundus.commons.assets.AssetManager;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
 import com.mbrlabs.mundus.commons.dto.SceneDTO;
+import com.mbrlabs.mundus.commons.env.lights.BaseLight;
+import com.mbrlabs.mundus.commons.mapper.BaseLightConverter;
+import com.mbrlabs.mundus.commons.mapper.FogConverter;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.commons.water.WaterResolution;
 import com.mbrlabs.mundus.runtime.Shaders;
 
 /**
@@ -37,6 +41,21 @@ public class SceneConverter {
         // meta
         scene.setId(dto.getId());
         scene.setName(dto.getName());
+        scene.skyboxAssetId = dto.getSkyboxAssetId();
+
+        // environment stuff
+        scene.environment.setFog(FogConverter.convert(dto.getFog()));
+        BaseLight ambientLight = BaseLightConverter.convert(dto.getAmbientLight());
+        if (ambientLight != null) {
+            scene.environment.setAmbientLight(ambientLight);
+        }
+
+        // Water stuff
+        scene.waterResolution = dto.getWaterResolution();
+        if (scene.waterResolution == null)
+            scene.waterResolution = WaterResolution.DEFAULT_WATER_RESOLUTION;
+
+        scene.waterHeight = dto.getWaterHeight();
 
         // scene graph
         scene.sceneGraph = new SceneGraph(scene);


### PR DESCRIPTION
This PR includes the following:

- Update skyboxes in README
- Update changes files to catch up with 0.3.0
- Enable fog on runtime
- Enable support for skyboxes on runtime
- Update runtime to v0.3.0

Jitpack requires a release so the plan is to create a 0.3.0 release after this PR then look into JitPack implementation for the runtime

Screenshot of skybox and fog functioning in runtime
![image](https://user-images.githubusercontent.com/28971753/167949727-ad9c2b21-4f08-447c-ac9a-0863384c76b3.png)
