### PR TITLE
Add thumbnails for TextureAssets in asset dock

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -8,6 +8,7 @@
 - Added a Log bar and dock to bottom of editor
 - Added SkyboxAsset and completed static Skybox feature, PR #33
 - Updated terrains for modifiable UV scale
+- Updated assets bar to include thumbnails of texture assets
 - Fixed NPE crash on GLTF model loading
 - Fixed rotation of models on import preview
 


### PR DESCRIPTION
Small PR to add texture thumbnails to texture assets. The assets section has a long way to go, but this is a small step in improving it.

![textureasset](https://user-images.githubusercontent.com/28971753/168493056-67ffc26a-b96c-41c4-840c-955b2efdca2d.gif)
