### PR TITLE
Fix water FBO rendering issue

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/WaterComponentWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/WaterComponentWidget.kt
@@ -35,9 +35,7 @@ class WaterComponentWidget(waterComponent: WaterComponent) :
     init {
         val label = VisLabel()
         label.wrap = true
-        label.setText("Water reflections may not render properly in the editor due to framebuffer and viewport conflicts" +
-                " but they will render properly during runtime and full screen view (F8)."
-                + " \n\nNOTE: All water instances must have the same height (Y value) for proper reflections.")
+        label.setText("NOTE: All water instances must have the same height (Y value) for proper reflections.")
         collapsibleContent.add(label).grow().padBottom(10f).row()
 
         collapsibleContent.add(VisLabel("Settings")).left().row()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusMultiSplitPane.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusMultiSplitPane.java
@@ -331,7 +331,7 @@ public class MundusMultiSplitPane extends WidgetGroup {
         for (int i = 0; i < actors.size; i++) {
             Actor actor = actors.get(i);
 
-            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget */
+            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget, See PR #37 */
             if (actor instanceof RenderWidget) {
                 if (actor.isVisible()) actor.draw(batch, parentAlpha * color.a);
                 continue;

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusMultiSplitPane.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusMultiSplitPane.java
@@ -330,6 +330,13 @@ public class MundusMultiSplitPane extends WidgetGroup {
         SnapshotArray<Actor> actors = getChildren();
         for (int i = 0; i < actors.size; i++) {
             Actor actor = actors.get(i);
+
+            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget */
+            if (actor instanceof RenderWidget) {
+                if (actor.isVisible()) actor.draw(batch, parentAlpha * color.a);
+                continue;
+            }
+
             Rectangle bounds = widgetBounds.get(i);
             Rectangle scissor = scissors.get(i);
             getStage().calculateScissors(bounds, scissor);

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusSplitPane.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusSplitPane.java
@@ -348,7 +348,7 @@ public class MundusSplitPane extends WidgetGroup {
         applyTransform(batch, computeTransform());
         // Matrix4 transform = batch.getTransformMatrix();
         if (firstWidget != null) {
-            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget */
+            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget, See PR #37 */
             if (firstWidget.isAscendantOf(UI.INSTANCE.getSceneWidget())) {
                 if (firstWidget.isVisible()) firstWidget.draw(batch, parentAlpha * color.a);
             }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusSplitPane.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MundusSplitPane.java
@@ -37,6 +37,7 @@ import com.kotcrab.vis.ui.FocusManager;
 import com.kotcrab.vis.ui.VisUI;
 import com.kotcrab.vis.ui.util.CursorManager;
 import com.kotcrab.vis.ui.widget.VisSplitPane;
+import com.mbrlabs.mundus.editor.ui.UI;
 
 /**
  * This is a slightly modified version of kotcrab's VisSplitPane and fixes an
@@ -347,11 +348,17 @@ public class MundusSplitPane extends WidgetGroup {
         applyTransform(batch, computeTransform());
         // Matrix4 transform = batch.getTransformMatrix();
         if (firstWidget != null) {
-            getStage().calculateScissors(firstWidgetBounds, firstScissors);
-            if (ScissorStack.pushScissors(firstScissors)) {
+            /* Skip Scissors on RenderWidget as it causes FBO rendering issues in RenderWidget */
+            if (firstWidget.isAscendantOf(UI.INSTANCE.getSceneWidget())) {
                 if (firstWidget.isVisible()) firstWidget.draw(batch, parentAlpha * color.a);
-                batch.flush();
-                ScissorStack.popScissors();
+            }
+            else {
+                getStage().calculateScissors(firstWidgetBounds, firstScissors);
+                if (ScissorStack.pushScissors(firstScissors)) {
+                    if (firstWidget.isVisible()) firstWidget.draw(batch, parentAlpha * color.a);
+                    batch.flush();
+                    ScissorStack.popScissors();
+                }
             }
         }
         if (secondWidget != null) {


### PR DESCRIPTION
Well I am happy! This took a few weeks to figure out but it turns out the odd rendering issue with Water (FBO's in general) when not in fullscreen is due to use of ScissorStack glScissors in the Mundus Splitpane classes. 

I have edited the classes to NOT perform glScissors on the RenderWidget. This appears to resolve the rendering issue and I am not seeing any negative impacts from the change. 

**Before fix:**
![image](https://user-images.githubusercontent.com/28971753/168494807-9c6a0623-8abb-457c-9a53-010bab9127ce.png)

**After this fix:**
![image](https://user-images.githubusercontent.com/28971753/168494834-400607cd-7008-447e-8d1e-281f7e006bd3.png)

