### PR TITLE
Replaced custom dist method to Vector2.dst method

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/MathUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/MathUtils.java
@@ -33,10 +33,6 @@ public class MathUtils {
         return l1 * p1.y + l2 * p2.y + l3 * p3.y;
     }
 
-    public static float dst(float x1, float y1, float x2, float y2) {
-        return (float) Math.sqrt(Math.pow((x2 - x1), 2) + Math.pow((y2 - y1), 2));
-    }
-
     /**
      * Angle between 2 points.
      *

--- a/commons/src/test/com/mbrlabs/mundus/commons/utils/MathUtilsTest.java
+++ b/commons/src/test/com/mbrlabs/mundus/commons/utils/MathUtilsTest.java
@@ -18,11 +18,6 @@ public class MathUtilsTest {
     }
 
     @Test
-    public void dst() throws Exception {
-        assertEquals(1.0f, MathUtils.dst(1.0f, 1.0f, 2.0f, 1.0f), 0.0f);
-    }
-
-    @Test
     public void angle() throws Exception {
         assertEquals(45.0f, MathUtils.angle(0.0f,0.0f,1.0f,1.0f), 0.0f);
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/ScaleTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/ScaleTool.java
@@ -15,6 +15,7 @@
  */
 package com.mbrlabs.mundus.editor.tools;
 
+import com.badlogic.gdx.math.Vector2;
 import org.lwjgl.opengl.GL11;
 
 import com.badlogic.gdx.Gdx;
@@ -230,7 +231,7 @@ public class ScaleTool extends TransformTool {
                     viewport3d.getScreenY(), viewport3d.getWorldWidth(), viewport3d.getWorldHeight());
             Vector3 mouse = temp1.set(Gdx.input.getX(), Gdx.graphics.getHeight() - Gdx.input.getY(), 0);
 
-            return MathUtils.dst(pivot.x, pivot.y, mouse.x, mouse.y);
+            return Vector2.dst(pivot.x, pivot.y, mouse.x, mouse.y);
         }
         return 0;
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/brushes/TerrainBrush.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/brushes/TerrainBrush.java
@@ -171,7 +171,7 @@ public abstract class TerrainBrush extends Tool {
 
         for (int smX = 0; smX < pixmap.getWidth(); smX++) {
             for (int smY = 0; smY < pixmap.getHeight(); smY++) {
-                final float dst = MathUtils.dst(splatX, splatY, smX, smY);
+                final float dst = Vector2.dst(splatX, splatY, smX, smY);
                 if (dst <= splatRad) {
                     final float opacity = getValueOfBrushPixmap(splatX, splatY, smX, smY, splatRad) * 0.5f * strength;
                     int newPixelColor = sm.additiveBlend(pixmap.getPixel(smX, smY), paintChannel, opacity);


### PR DESCRIPTION
I think a custom method is unnecessary if it is already in a library, so I replaced MathUtils.dst method to Vector2.dst method.