### PR TITLE
Add normal maps to terrains and models

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/MaterialAsset.java
@@ -111,6 +111,11 @@ public class MaterialAsset extends Asset {
         } else {
             material.remove(TextureAttribute.Diffuse);
         }
+        if (normalMap != null) {
+            material.set(new TextureAttribute(TextureAttribute.Normal, normalMap.getTexture()));
+        } else {
+            material.remove(TextureAttribute.Normal);
+        }
         material.set(new FloatAttribute(FloatAttribute.Shininess, shininess));
 
         return material;
@@ -138,7 +143,11 @@ public class MaterialAsset extends Asset {
 
     public void setNormalMap(TextureAsset normalMap) {
         this.normalMap = normalMap;
-        normalMapID = normalMap.getID();
+        if (normalMap != null) {
+            this.normalMapID = normalMap.getID();
+        } else {
+            this.normalMapID = null;
+        }
     }
 
     public TextureAsset getDiffuseTexture() {

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/TerrainAsset.java
@@ -46,6 +46,11 @@ public class TerrainAsset extends Asset {
     private TextureAsset splatG;
     private TextureAsset splatB;
     private TextureAsset splatA;
+    private TextureAsset splatBaseNormal;
+    private TextureAsset splatRNormal;
+    private TextureAsset splatBNormal;
+    private TextureAsset splatGNormal;
+    private TextureAsset splatANormal;
 
     private Terrain terrain;
 
@@ -137,6 +142,71 @@ public class TerrainAsset extends Asset {
         }
     }
 
+    public TextureAsset getSplatBaseNormal() {
+        return splatBaseNormal;
+    }
+
+    public void setSplatBaseNormal(TextureAsset splatBaseNormal) {
+        this.splatBaseNormal = splatBaseNormal;
+        if (splatBaseNormal == null) {
+            meta.getTerrain().setSplatBaseNormal(null);
+        } else {
+            meta.getTerrain().setSplatBaseNormal(splatBaseNormal.getID());
+        }
+    }
+
+    public TextureAsset getSplatRNormal() {
+        return splatRNormal;
+    }
+
+    public void setSplatRNormal(TextureAsset splatRNormal) {
+        this.splatRNormal = splatRNormal;
+        if (splatRNormal == null) {
+            meta.getTerrain().setSplatRNormal(null);
+        } else {
+            meta.getTerrain().setSplatRNormal(splatRNormal.getID());
+        }
+    }
+
+    public TextureAsset getSplatBNormal() {
+        return splatBNormal;
+    }
+
+    public void setSplatBNormal(TextureAsset splatBNormal) {
+        this.splatBNormal = splatBNormal;
+        if (splatBNormal == null) {
+            meta.getTerrain().setSplatBNormal(null);
+        } else {
+            meta.getTerrain().setSplatBNormal(splatBNormal.getID());
+        }
+    }
+
+    public TextureAsset getSplatGNormal() {
+        return splatGNormal;
+    }
+
+    public void setSplatGNormal(TextureAsset splatGNormal) {
+        this.splatGNormal = splatGNormal;
+        if (splatGNormal == null) {
+            meta.getTerrain().setSplatGNormal(null);
+        } else {
+            meta.getTerrain().setSplatGNormal(splatGNormal.getID());
+        }
+    }
+
+    public TextureAsset getSplatANormal() {
+        return splatANormal;
+    }
+
+    public void setSplatANormal(TextureAsset splatANormal) {
+        this.splatANormal = splatANormal;
+        if (splatANormal == null) {
+            meta.getTerrain().setSplatANormal(null);
+        } else {
+            meta.getTerrain().setSplatANormal(splatANormal.getID());
+        }
+    }
+
     public Terrain getTerrain() {
         return terrain;
     }
@@ -210,6 +280,36 @@ public class TerrainAsset extends Asset {
         if (id != null && assets.containsKey(id)) {
             setSplatA((TextureAsset) assets.get(id));
         }
+
+        // splat normal channel base
+        id = meta.getTerrain().getSplatBaseNormal();
+        if (id != null && assets.containsKey(id)) {
+            setSplatBaseNormal((TextureAsset) assets.get(id));
+        }
+
+        // splat normal channel r
+        id = meta.getTerrain().getSplatRNormal();
+        if (id != null && assets.containsKey(id)) {
+            setSplatRNormal((TextureAsset) assets.get(id));
+        }
+
+        // splat normal channel g
+        id = meta.getTerrain().getSplatGNormal();
+        if (id != null && assets.containsKey(id)) {
+            setSplatGNormal((TextureAsset) assets.get(id));
+        }
+
+        // splat normal channel b
+        id = meta.getTerrain().getSplatBNormal();
+        if (id != null && assets.containsKey(id)) {
+            setSplatBNormal((TextureAsset) assets.get(id));
+        }
+
+        // splat normal channel a
+        id = meta.getTerrain().getSplatANormal();
+        if (id != null && assets.containsKey(id)) {
+            setSplatANormal((TextureAsset) assets.get(id));
+        }
     }
 
     @Override
@@ -245,6 +345,32 @@ public class TerrainAsset extends Asset {
             terrainTexture.removeTexture(SplatTexture.Channel.A);
         } else {
             terrainTexture.setSplatTexture(new SplatTexture(SplatTexture.Channel.A, splatA));
+        }
+
+        if (splatBaseNormal == null) {
+            terrainTexture.removeNormalTexture(SplatTexture.Channel.BASE);
+        } else {
+            terrainTexture.setSplatNormalTexture(new SplatTexture(SplatTexture.Channel.BASE, splatBaseNormal));
+        }
+        if (splatRNormal == null) {
+            terrainTexture.removeNormalTexture(SplatTexture.Channel.R);
+        } else {
+            terrainTexture.setSplatNormalTexture(new SplatTexture(SplatTexture.Channel.R, splatRNormal));
+        }
+        if (splatGNormal == null) {
+            terrainTexture.removeNormalTexture(SplatTexture.Channel.G);
+        } else {
+            terrainTexture.setSplatNormalTexture(new SplatTexture(SplatTexture.Channel.G, splatGNormal));
+        }
+        if (splatBNormal == null) {
+            terrainTexture.removeNormalTexture(SplatTexture.Channel.B);
+        } else {
+            terrainTexture.setSplatNormalTexture(new SplatTexture(SplatTexture.Channel.B, splatBNormal));
+        }
+        if (splatANormal == null) {
+            terrainTexture.removeNormalTexture(SplatTexture.Channel.A);
+        } else {
+            terrainTexture.setSplatNormalTexture(new SplatTexture(SplatTexture.Channel.A, splatANormal));
         }
 
         terrain.update();

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -66,6 +66,11 @@ public class MetaLoader {
         terrain.setSplatG(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_G, null));
         terrain.setSplatB(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_B, null));
         terrain.setSplatA(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_A, null));
+        terrain.setSplatBaseNormal(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_BASE_NORMAL, null));
+        terrain.setSplatRNormal(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_R_NORMAL, null));
+        terrain.setSplatGNormal(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_G_NORMAL, null));
+        terrain.setSplatBNormal(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_B_NORMAL, null));
+        terrain.setSplatANormal(jsonTerrain.getString(MetaTerrain.JSON_SPLAT_A_NORMAL, null));
 
         meta.setTerrain(terrain);
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaTerrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaTerrain.java
@@ -31,6 +31,11 @@ public class MetaTerrain {
     public static final String JSON_SPLAT_G = "g";
     public static final String JSON_SPLAT_B = "b";
     public static final String JSON_SPLAT_A = "a";
+    public static final String JSON_SPLAT_BASE_NORMAL = "baseNorm";
+    public static final String JSON_SPLAT_R_NORMAL = "rNorm";
+    public static final String JSON_SPLAT_G_NORMAL = "gNorm";
+    public static final String JSON_SPLAT_B_NORMAL = "bNorm";
+    public static final String JSON_SPLAT_A_NORMAL = "aNorm";
     public static final String JSON_UV_SCALE= "uv";
 
     private int size;
@@ -42,6 +47,11 @@ public class MetaTerrain {
     private String splatG;
     private String splatB;
     private String splatA;
+    private String splatBaseNormal;
+    private String splatRNormal;
+    private String splatGNormal;
+    private String splatBNormal;
+    private String splatANormal;
 
     public String getSplatmap() {
         return splatmap;
@@ -115,6 +125,46 @@ public class MetaTerrain {
         this.uv = uv;
     }
 
+    public String getSplatBaseNormal() {
+        return splatBaseNormal;
+    }
+
+    public void setSplatBaseNormal(String splatBaseNormal) {
+        this.splatBaseNormal = splatBaseNormal;
+    }
+
+    public String getSplatRNormal() {
+        return splatRNormal;
+    }
+
+    public void setSplatRNormal(String splatRNormal) {
+        this.splatRNormal = splatRNormal;
+    }
+
+    public String getSplatGNormal() {
+        return splatGNormal;
+    }
+
+    public void setSplatGNormal(String splatGNormal) {
+        this.splatGNormal = splatGNormal;
+    }
+
+    public String getSplatBNormal() {
+        return splatBNormal;
+    }
+
+    public void setSplatBNormal(String splatBNormal) {
+        this.splatBNormal = splatBNormal;
+    }
+
+    public String getSplatANormal() {
+        return splatANormal;
+    }
+
+    public void setSplatANormal(String splatANormal) {
+        this.splatANormal = splatANormal;
+    }
+
     @Override
     public String toString() {
         return "MetaTerrain{" +
@@ -127,6 +177,11 @@ public class MetaTerrain {
                 ", splatG='" + splatG + '\'' +
                 ", splatB='" + splatB + '\'' +
                 ", splatA='" + splatA + '\'' +
+                ", splatBaseNormal='" + splatBaseNormal + '\'' +
+                ", splatRNormal='" + splatRNormal + '\'' +
+                ", splatGNormal='" + splatGNormal + '\'' +
+                ", splatBNormal='" + splatBNormal + '\'' +
+                ", splatANormal='" + splatANormal + '\'' +
                 '}';
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/ModelShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/ModelShader.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.graphics.g3d.attributes.FloatAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.math.Matrix3;
 import com.mbrlabs.mundus.commons.env.Fog;
 import com.mbrlabs.mundus.commons.env.MundusEnvironment;
 import com.mbrlabs.mundus.commons.utils.ShaderUtils;
@@ -41,17 +42,22 @@ public class ModelShader extends LightShader {
     // ============================ MATERIALS ============================
     protected final int UNIFORM_MATERIAL_DIFFUSE_TEXTURE = register(new Uniform("u_diffuseTexture"));
     protected final int UNIFORM_MATERIAL_DIFFUSE_USE_TEXTURE = register(new Uniform("u_diffuseUseTexture"));
+    protected final int UNIFORM_MATERIAL_NORMAL_TEXTURE = register(new Uniform("u_normalTexture"));
+    protected final int UNIFORM_MATERIAL_NORMAL_USE_TEXTURE = register(new Uniform("u_useNormalMap"));
 
 
     // ============================ MATRICES & CAM POSITION ============================
     protected final int UNIFORM_PROJ_VIEW_MATRIX = register(new Uniform("u_projViewMatrix"));
     protected final int UNIFORM_TRANS_MATRIX = register(new Uniform("u_transMatrix"));
+    protected final int UNIFORM_NORMAL_MATRIX = register(new Uniform("u_normalMatrix"));
     protected final int UNIFORM_CAM_POS = register(new Uniform("u_camPos"));
 
     // ============================ FOG ============================
     protected final int UNIFORM_FOG_DENSITY = register(new Uniform("u_fogDensity"));
     protected final int UNIFORM_FOG_GRADIENT = register(new Uniform("u_fogGradient"));
     protected final int UNIFORM_FOG_COLOR = register(new Uniform("u_fogColor"));
+
+    private final Matrix3 tmpM = new Matrix3();
 
     private ShaderProgram program;
 
@@ -97,9 +103,11 @@ public class ModelShader extends LightShader {
 
         setLights(env);
         set(UNIFORM_TRANS_MATRIX, renderable.worldTransform);
+        set(UNIFORM_NORMAL_MATRIX, tmpM.set(renderable.worldTransform).inv().transpose());
 
         // texture uniform
         TextureAttribute diffuseTexture = ((TextureAttribute) (renderable.material.get(TextureAttribute.Diffuse)));
+        TextureAttribute normalMap = ((TextureAttribute) (renderable.material.get(TextureAttribute.Normal)));
         ColorAttribute diffuseColor = ((ColorAttribute) (renderable.material.get(ColorAttribute.Diffuse)));
 
         if (diffuseTexture != null) {
@@ -107,6 +115,13 @@ public class ModelShader extends LightShader {
             set(UNIFORM_MATERIAL_DIFFUSE_USE_TEXTURE, 1);
         } else {
             set(UNIFORM_MATERIAL_DIFFUSE_USE_TEXTURE, 0);
+        }
+
+        if (normalMap != null) {
+            set(UNIFORM_MATERIAL_NORMAL_TEXTURE, normalMap.textureDescription.texture);
+            set(UNIFORM_MATERIAL_NORMAL_USE_TEXTURE, 1);
+        } else {
+            set(UNIFORM_MATERIAL_NORMAL_USE_TEXTURE, 0);
         }
 
         set(UNIFORM_USE_MATERIAL, 1); // Use material for lighting

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/TerrainShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/TerrainShader.java
@@ -146,11 +146,20 @@ public class TerrainShader extends LightShader {
                 .get(TerrainTextureAttribute.ATTRIBUTE_SPLAT0);
         final TerrainTexture terrainTexture = splatAttrib.terrainTexture;
 
+        // Does terrain have normal maps
+        boolean hasNormals = terrainTexture.hasNormalTextures();
+        if (hasNormals) {
+            set(UNIFORM_TEXTURE_HAS_NORMALS, 1);
+        } else {
+            set(UNIFORM_TEXTURE_HAS_NORMALS, 0);
+        }
+
         // base texture
         SplatTexture st = terrainTexture.getTexture(SplatTexture.Channel.BASE);
         if (st != null) {
             set(UNIFORM_TEXTURE_BASE, st.texture.getTexture());
             set(UNIFORM_TEXTURE_HAS_DIFFUSE, 1);
+            setNormalTexture(terrainTexture, SplatTexture.Channel.BASE, UNIFORM_TEXTURE_BASE_NORMAL, UNIFORM_TEXTURE_BASE_NORMAL_PRESENT);
         } else {
             set(UNIFORM_TEXTURE_HAS_DIFFUSE, 0);
         }
@@ -169,15 +178,11 @@ public class TerrainShader extends LightShader {
             if (st != null) set(UNIFORM_TEXTURE_A, st.texture.getTexture());
 
             // Normal maps
-            if (terrainTexture.hasNormalTextures()) {
-                set(UNIFORM_TEXTURE_HAS_NORMALS, 1);
-                setNormalTexture(terrainTexture, SplatTexture.Channel.BASE, UNIFORM_TEXTURE_BASE_NORMAL, UNIFORM_TEXTURE_BASE_NORMAL_PRESENT);
+            if (hasNormals) {
                 setNormalTexture(terrainTexture, SplatTexture.Channel.R, UNIFORM_TEXTURE_R_NORMAL, UNIFORM_TEXTURE_R_NORMAL_PRESENT);
                 setNormalTexture(terrainTexture, SplatTexture.Channel.G, UNIFORM_TEXTURE_G_NORMAL, UNIFORM_TEXTURE_G_NORMAL_PRESENT);
                 setNormalTexture(terrainTexture, SplatTexture.Channel.B, UNIFORM_TEXTURE_B_NORMAL, UNIFORM_TEXTURE_B_NORMAL_PRESENT);
                 setNormalTexture(terrainTexture, SplatTexture.Channel.A, UNIFORM_TEXTURE_A_NORMAL, UNIFORM_TEXTURE_A_NORMAL_PRESENT);
-            } else {
-                set(UNIFORM_TEXTURE_HAS_NORMALS, 0);
             }
 
         } else {

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.frag.glsl
@@ -36,12 +36,15 @@ varying vec3 v_normal;
 
 // diffuse material
 uniform sampler2D   u_diffuseTexture;
+uniform sampler2D   u_normalTexture;
 uniform int         u_diffuseUseTexture;
+uniform int         u_useNormalMap;
 
 // enviroment
 uniform MED vec4 u_fogColor;
 
 varying float v_clipDistance;
+varying mat3 v_TBN;
 
 void main(void) {
     if ( v_clipDistance < 0.0 )
@@ -56,16 +59,25 @@ void main(void) {
         gl_FragColor = vec4(u_material.DiffuseColor, 1.0);
     }
 
-    vec4 totalLight = CalcDirectionalLight(v_normal);
+    vec3 normal;
+
+    if (u_useNormalMap == 1) {
+        normal = texture2D(u_normalTexture, v_texCoord0);
+        normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
+    } else {
+        normal = v_normal;
+    }
+
+    vec4 totalLight = CalcDirectionalLight(normal);
 
     for (int i = 0 ; i < numPointLights ; i++) {
         if (i >= u_activeNumPointLights){break;}
-        totalLight += CalcPointLight(u_pointLights[i], v_normal);
+        totalLight += CalcPointLight(u_pointLights[i], normal);
     }
 
     for (int i = 0 ; i < numSpotLights; i++) {
         if (i >= u_activeNumSpotLights){break;}
-        totalLight += CalcSpotLight(u_spotLights[i], v_normal);
+        totalLight += CalcSpotLight(u_spotLights[i], normal);
     }
 
     gl_FragColor = max(gl_FragColor, AMBIENT); // TODO make ambient color a unifrom

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.frag.glsl
@@ -62,7 +62,7 @@ void main(void) {
     vec3 normal;
 
     if (u_useNormalMap == 1) {
-        normal = texture2D(u_normalTexture, v_texCoord0);
+        normal = texture2D(u_normalTexture, v_texCoord0).rgb;
         normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
     } else {
         normal = v_normal;

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.vert.glsl
@@ -21,9 +21,11 @@ precision highp float;
 attribute vec3 a_position;
 attribute vec3 a_normal;
 attribute vec2 a_texCoord0;
+attribute vec4 a_tangent;
 
 uniform mat4 u_transMatrix;
 uniform mat4 u_projViewMatrix;
+uniform mat3 u_normalMatrix;
 uniform vec3 u_camPos;
 
 // Fog
@@ -34,6 +36,8 @@ varying float v_fog;
 varying vec2 v_texCoord0;
 varying vec3 v_normal;
 varying vec3 v_worldPos;
+varying mat3 v_TBN;
+
 
 // clipping plane
 varying float v_clipDistance;
@@ -54,6 +58,13 @@ void main(void) {
     // normal for lighting
     v_normal = normalize((u_transMatrix * vec4(a_normal, 0.0)).xyz);
     v_worldPos = worldPos.xyz;
+
+    // Logic for Tangent/Bi-tangent/Normal from gdx-gltf
+    vec3 tangent = a_tangent.xyz;
+    vec3 normalW = normalize(vec3(u_normalMatrix * a_normal.xyz));
+    vec3 tangentW = normalize(vec3(u_transMatrix * vec4(tangent, 0.0)));
+    vec3 bitangentW = cross(normalW, tangentW) * a_tangent.w;
+    v_TBN = mat3(tangentW, bitangentW, normalW);
 
     // =================================================================
     //                          /Lighting

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.frag.glsl
@@ -80,11 +80,15 @@ void main(void) {
     if ( v_clipDistance < 0.0 )
         discard;
 
-    vec3 normal = v_TBN[2];
+    vec3 normal;
 
     // blend textures
     if(u_texture_has_diffuse == 1) {
         gl_FragColor = texture2D(u_texture_base, v_texCoord0);
+
+        if (u_texture_has_normal_base == 1) {
+            normal = texture2D(u_texture_base_normal, v_texCoord0).rgb;
+        }
     }
     if(u_texture_has_splatmap == 1) {
         vec4 splat = texture2D(u_texture_splat, splatPosition);
@@ -95,11 +99,6 @@ void main(void) {
 
         // Mix in splat map normals
         if (u_texture_has_normals == 1) {
-            if (u_texture_has_normal_base == 1) {
-                normal = texture2D(u_texture_base_normal, v_texCoord0).rgb;
-            } else {
-                normal = vec3(1);
-            }
 
             if (u_texture_has_normal_r == 1) {
                 normal = mix(normal, texture2D(u_texture_r_normal, v_texCoord0).rgb, splat.r);
@@ -114,8 +113,13 @@ void main(void) {
                 normal = mix(normal, texture2D(u_texture_a_normal, v_texCoord0).rgb, splat.a);
             }
 
-            normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
         }
+    }
+
+    if (u_texture_has_normals == 1) {
+        normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
+    } else {
+        normal = normalize(v_TBN[2].xyz);
     }
 
     // =================================================================

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.frag.glsl
@@ -43,6 +43,19 @@ uniform sampler2D u_texture_splat;
 uniform int u_texture_has_splatmap;
 uniform int u_texture_has_diffuse;
 
+// splat normal texture
+uniform int u_texture_has_normals;
+uniform int u_texture_has_normal_base;
+uniform int u_texture_has_normal_r;
+uniform int u_texture_has_normal_g;
+uniform int u_texture_has_normal_b;
+uniform int u_texture_has_normal_a;
+uniform sampler2D u_texture_base_normal;
+uniform sampler2D u_texture_r_normal;
+uniform sampler2D u_texture_g_normal;
+uniform sampler2D u_texture_b_normal;
+uniform sampler2D u_texture_a_normal;
+
 // mouse picking
 #ifdef PICKER
 uniform vec3 u_pickerPos;
@@ -55,18 +68,19 @@ uniform MED vec4 u_fogColor;
 
 // light
 varying vec3 v_normal;
+varying mat3 v_TBN;
 
 varying MED vec2 v_texCoord0;
 varying float v_fog;
 
 varying vec2 splatPosition;
-
-
 varying float v_clipDistance;
 
 void main(void) {
     if ( v_clipDistance < 0.0 )
         discard;
+
+    vec3 normal = v_TBN[2];
 
     // blend textures
     if(u_texture_has_diffuse == 1) {
@@ -78,21 +92,45 @@ void main(void) {
         gl_FragColor = mix(gl_FragColor, texture2D(u_texture_g, v_texCoord0), splat.g);
         gl_FragColor = mix(gl_FragColor, texture2D(u_texture_b, v_texCoord0), splat.b);
         gl_FragColor = mix(gl_FragColor, texture2D(u_texture_a, v_texCoord0), splat.a);
+
+        // Mix in splat map normals
+        if (u_texture_has_normals == 1) {
+            if (u_texture_has_normal_base == 1) {
+                normal = texture2D(u_texture_base_normal, v_texCoord0).rgb;
+            } else {
+                normal = vec3(1);
+            }
+
+            if (u_texture_has_normal_r == 1) {
+                normal = mix(normal, texture2D(u_texture_r_normal, v_texCoord0).rgb, splat.r);
+            }
+            if (u_texture_has_normal_g == 1) {
+                normal = mix(normal, texture2D(u_texture_g_normal, v_texCoord0).rgb, splat.g);
+            }
+            if (u_texture_has_normal_b == 1) {
+                normal = mix(normal, texture2D(u_texture_b_normal, v_texCoord0).rgb, splat.b);
+            }
+            if (u_texture_has_normal_a == 1) {
+                normal = mix(normal, texture2D(u_texture_a_normal, v_texCoord0).rgb, splat.a);
+            }
+
+            normal = normalize(v_TBN * ((2.0 * normal - 1.0)));
+        }
     }
 
     // =================================================================
     //                          Lighting
     // =================================================================
-    vec4 totalLight = CalcDirectionalLight(v_normal);
+    vec4 totalLight = CalcDirectionalLight(normal);
 
     for (int i = 0 ; i < numPointLights ; i++) {
         if (i >= u_activeNumPointLights){break;}
-        totalLight += CalcPointLight(u_pointLights[i], v_normal);
+        totalLight += CalcPointLight(u_pointLights[i], normal);
     }
 
     for (int i = 0; i < numSpotLights; i++) {
         if (i >= u_activeNumSpotLights){break;}
-        totalLight += CalcSpotLight(u_spotLights[i], v_normal);
+        totalLight += CalcSpotLight(u_spotLights[i], normal);
     }
 
     gl_FragColor *= totalLight;

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.vert.glsl
@@ -21,10 +21,12 @@ precision highp float;
 attribute vec3 a_position;
 attribute vec3 a_normal;
 attribute vec2 a_texCoord0;
+attribute vec4 a_tangent;
 
 uniform mat4 u_transMatrix;
 uniform mat4 u_projViewMatrix;
 uniform vec3 u_camPos;
+uniform mat3 u_normalMatrix;
 
 // Fog
 uniform float u_fogDensity;
@@ -37,6 +39,7 @@ varying vec2 splatPosition;
 varying float v_fog;
 varying vec3 v_normal;
 varying vec3 v_worldPos;
+varying mat3 v_TBN;
 
 #ifdef PICKER
 varying vec3 v_pos;
@@ -53,6 +56,13 @@ void main(void) {
 
     // normal for lighting
     v_normal = normalize((u_transMatrix * vec4(a_normal, 0.0)).xyz);
+
+    // Logic for Tangent/Bi-tangent/Normal from gdx-gltf
+    vec3 tangent = a_tangent.xyz;
+    vec3 normalW = normalize(vec3(u_normalMatrix * a_normal.xyz));
+    vec3 tangentW = normalize(vec3(u_transMatrix * vec4(tangent, 0.0)));
+    vec3 bitangentW = cross(normalW, tangentW) * a_tangent.w;
+    v_TBN = mat3(tangentW, bitangentW, normalW);
 
     // clipping plane
     v_clipDistance = dot(worldPos, u_clipPlane);

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainTexture.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainTexture.java
@@ -25,16 +25,22 @@ import java.util.Map;
  */
 public class TerrainTexture {
 
-    private Map<SplatTexture.Channel, SplatTexture> textures;
+    private final Map<SplatTexture.Channel, SplatTexture> textures;
+    private final Map<SplatTexture.Channel, SplatTexture> normalTextures;
     private SplatMap splatmap;
     private Terrain terrain;
 
     public TerrainTexture() {
-        textures = new HashMap<SplatTexture.Channel, SplatTexture>(5, 1);
+        textures = new HashMap<>(5, 1);
+        normalTextures = new HashMap<>(5, 1);
     }
 
     public SplatTexture getTexture(SplatTexture.Channel channel) {
         return textures.get(channel);
+    }
+
+    public SplatTexture getNormalTexture(SplatTexture.Channel channel) {
+        return normalTextures.get(channel);
     }
 
     public void removeTexture(SplatTexture.Channel channel) {
@@ -45,8 +51,16 @@ public class TerrainTexture {
         }
     }
 
+    public void removeNormalTexture(SplatTexture.Channel channel) {
+            normalTextures.remove(channel);
+    }
+
     public void setSplatTexture(SplatTexture tex) {
         textures.put(tex.channel, tex);
+    }
+
+    public void setSplatNormalTexture(SplatTexture tex) {
+        normalTextures.put(tex.channel, tex);
     }
 
     public SplatTexture.Channel getNextFreeChannel() {
@@ -95,6 +109,10 @@ public class TerrainTexture {
 
     public void setTerrain(Terrain terrain) {
         this.terrain = terrain;
+    }
+
+    public boolean hasNormalTextures() {
+        return normalTextures.size() > 0;
     }
 
 }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -3,6 +3,7 @@
 - Added new Light Component and accompanying Light Shader which prefixes shaders with additional shader lighting code.
 - Added new Add Component Dialog which only supports Light Components for now.
 - Added new Gizmo feature for displaying decal Icons over objects like Light sources.
+- Added normal mapping for terrains
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 
 [0.3.1] ~ 07/06/2022

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -3,7 +3,7 @@
 - Added new Light Component and accompanying Light Shader which prefixes shaders with additional shader lighting code.
 - Added new Add Component Dialog which only supports Light Components for now.
 - Added new Gizmo feature for displaying decal Icons over objects like Light sources.
-- Added normal mapping for terrains
+- Added normal mapping for terrains and models
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 
 [0.3.1] ~ 07/06/2022

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
@@ -82,6 +82,11 @@ class MetaSaver {
         if (terrain.splatG != null) json.writeValue(MetaTerrain.JSON_SPLAT_G, terrain.splatG)
         if (terrain.splatB != null) json.writeValue(MetaTerrain.JSON_SPLAT_B, terrain.splatB)
         if (terrain.splatA != null) json.writeValue(MetaTerrain.JSON_SPLAT_A, terrain.splatA)
+        if (terrain.splatBaseNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_BASE_NORMAL, terrain.splatBaseNormal)
+        if (terrain.splatRNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_R_NORMAL, terrain.splatRNormal)
+        if (terrain.splatGNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_G_NORMAL, terrain.splatGNormal)
+        if (terrain.splatBNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_B_NORMAL, terrain.splatBNormal)
+        if (terrain.splatANormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_A_NORMAL, terrain.splatANormal)
         json.writeObjectEnd()
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
@@ -227,12 +227,16 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
                         val terrain = parentWidget.component.terrain
                         if (channel == SplatTexture.Channel.R) {
                             terrain.splatR = null
+                            terrain.splatRNormal = null
                         } else if (channel == SplatTexture.Channel.G) {
                             terrain.splatG = null
+                            terrain.splatGNormal = null
                         } else if (channel == SplatTexture.Channel.B) {
                             terrain.splatB = null
+                            terrain.splatBNormal = null
                         } else if (channel == SplatTexture.Channel.A) {
                             terrain.splatA = null
+                            terrain.splatANormal = null
                         } else {
                             UI.toaster.error("Can't remove the base texture")
                             return

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
@@ -211,12 +211,15 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
 
         private val removeTexture = MenuItem("Remove texture")
         private val changeTexture = MenuItem("Change texture")
+        private val addNormalMap = MenuItem("Add Normal Map")
+        private val removeNormalMap = MenuItem("Remove Normal Map")
 
         private var channel: SplatTexture.Channel? = null
 
         init {
             addItem(removeTexture)
             addItem(changeTexture)
+            addItem(addNormalMap)
 
             removeTexture.addListener(object : ClickListener() {
                 override fun clicked(event: InputEvent?, x: Float, y: Float) {
@@ -272,6 +275,59 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
                 }
             })
 
+            addNormalMap.addListener(object : ClickListener() {
+                override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                    if (channel != null) {
+
+                        UI.assetSelectionDialog.show(false, AssetTextureFilter(), object: AssetPickerDialog.AssetPickerListener {
+                            override fun onSelected(asset: Asset?) {
+                                if (channel != null) {
+                                    val terrain = parentWidget.component.terrain
+                                    if (channel == SplatTexture.Channel.BASE) {
+                                        terrain.splatBaseNormal = asset as TextureAsset
+                                    } else if (channel == SplatTexture.Channel.R) {
+                                        terrain.splatRNormal = asset as TextureAsset
+                                    } else if (channel == SplatTexture.Channel.G) {
+                                        terrain.splatGNormal = asset as TextureAsset
+                                    } else if (channel == SplatTexture.Channel.B) {
+                                        terrain.splatBNormal = asset as TextureAsset
+                                    } else if (channel == SplatTexture.Channel.A) {
+                                        terrain.splatANormal = asset as TextureAsset
+                                    }
+
+                                    terrain.applyDependencies()
+                                    projectManager.current().assetManager.addModifiedAsset(terrain)
+                                }
+                            }
+                        })
+
+                    }
+                }
+            })
+
+            removeNormalMap.addListener(object : ClickListener() {
+                override fun clicked(event: InputEvent?, x: Float, y: Float) {
+                    if (channel != null) {
+                        val terrain = parentWidget.component.terrain
+                        if (channel == SplatTexture.Channel.BASE) {
+                            terrain.splatBaseNormal = null
+                        }
+                        if (channel == SplatTexture.Channel.R) {
+                            terrain.splatRNormal = null
+                        } else if (channel == SplatTexture.Channel.G) {
+                            terrain.splatGNormal = null
+                        } else if (channel == SplatTexture.Channel.B) {
+                            terrain.splatBNormal = null
+                        } else if (channel == SplatTexture.Channel.A) {
+                            terrain.splatANormal = null
+                        }
+
+                        terrain.applyDependencies()
+                        projectManager.current().assetManager.addModifiedAsset(terrain)
+                    }
+                }
+            })
+
         }
 
         fun setChannel(channel: SplatTexture.Channel) {
@@ -279,7 +335,32 @@ class TerrainPaintTab(private val parentWidget: TerrainComponentWidget) : Tab(fa
         }
 
         fun show() {
+            updateMenuVisibility()
             showMenu(UI, Gdx.input.x.toFloat(), (Gdx.graphics.height - Gdx.input.y).toFloat())
+        }
+
+        private fun updateMenuVisibility() {
+            // Show/Hide remove normal map button conditionally
+            var normalMapRemoveVisible = false
+            val terrain = parentWidget.component.terrain
+            if (channel == SplatTexture.Channel.BASE && terrain.splatBaseNormal != null) {
+                normalMapRemoveVisible = true
+            } else if (channel == SplatTexture.Channel.R && terrain.splatRNormal != null) {
+                normalMapRemoveVisible = true
+            } else if (channel == SplatTexture.Channel.G && terrain.splatGNormal != null) {
+                normalMapRemoveVisible = true
+            } else if (channel == SplatTexture.Channel.B && terrain.splatBNormal != null) {
+                normalMapRemoveVisible = true
+            } else if (channel == SplatTexture.Channel.A && terrain.splatANormal != null) {
+                normalMapRemoveVisible = true
+            }
+
+            if (normalMapRemoveVisible && !removeNormalMap.hasParent()) {
+                addItem(removeNormalMap)
+            } else if (!normalMapRemoveVisible) {
+                removeNormalMap.remove()
+            }
+            pack()
         }
 
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialWidget.kt
@@ -60,6 +60,7 @@ class MaterialWidget : VisTable() {
     private val matNameLabel: VisLabel = VisLabel()
     private val diffuseColorField: ColorPickerField = ColorPickerField()
     private val diffuseAssetField: AssetSelectionField = AssetSelectionField()
+    private val normalMapField: AssetSelectionField = AssetSelectionField()
     private val shininessField = VisTextField()
 
     private val projectManager: ProjectManager = Mundus.inject()
@@ -73,6 +74,7 @@ class MaterialWidget : VisTable() {
                 field = value
                 diffuseColorField.selectedColor = value.diffuseColor
                 diffuseAssetField.setAsset(value.diffuseTexture)
+                normalMapField.setAsset(value.normalMap)
                 matNameLabel.setText(value.name)
                 shininessField.text = value.shininess.toString()
             }
@@ -112,6 +114,8 @@ class MaterialWidget : VisTable() {
 
         add(VisLabel("Diffuse texture")).grow().row()
         add(diffuseAssetField).growX().row()
+        add(VisLabel("Normal map")).grow().row()
+        add(normalMapField).growX().row()
         add(VisLabel("Diffuse color")).grow().row()
         add(diffuseColorField).growX().row()
         add(VisLabel("Shininess")).growX().row()
@@ -128,6 +132,17 @@ class MaterialWidget : VisTable() {
         diffuseAssetField.pickerListener = object: AssetPickerDialog.AssetPickerListener {
             override fun onSelected(asset: Asset?) {
                 material?.diffuseTexture = asset as? TextureAsset
+                applyMaterialToModelAssets()
+                applyMaterialToModelComponents()
+                projectManager.current().assetManager.addModifiedAsset(material!!)
+            }
+        }
+
+        // normal texture
+        normalMapField.assetFilter = AssetTextureFilter()
+        normalMapField.pickerListener = object: AssetPickerDialog.AssetPickerListener {
+            override fun onSelected(asset: Asset?) {
+                material?.normalMap = asset as? TextureAsset
                 applyMaterialToModelAssets()
                 applyMaterialToModelComponents()
                 projectManager.current().assetManager.addModifiedAsset(material!!)


### PR DESCRIPTION
Adds the ability to add normal maps to terrains via simplified UI for a considerable improvement on the look of terrains.

- [x] Implement Normal Maps
- [x] Test desktop/mac
- [x] Test android
- [x] Test HTML
- [x] Update CHANGES


https://user-images.githubusercontent.com/28971753/176582752-ac910ab0-dfdd-43f1-9a1c-45473f632a79.mp4

https://user-images.githubusercontent.com/28971753/176691421-a945a4eb-f741-40a2-a7ba-c4ec44c80ed2.mp4


