### PR TITLE
Add basic shadows

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
@@ -138,6 +139,7 @@ public class Scene implements Disposable {
             setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
         }
         DirectionalLight light = LightUtils.getDirectionalLight(environment);
+        if (light == null) return;
 
         shadowMapper.setCenter(cam.position);
         shadowMapper.begin(light.direction);

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -277,7 +277,7 @@ public class Scene implements Disposable {
      */
     public void setShadowQuality(ShadowResolution shadowResolution) {
         DirectionalLight light = LightUtils.getDirectionalLight(environment);
-        if (light == null) return;
+        if (light == null || shadowResolution == null) return;
 
         if (shadowMapper == null) {
             shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, cam.far);

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -17,12 +17,10 @@
 package com.mbrlabs.mundus.commons;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
@@ -73,6 +71,8 @@ public class Scene implements Disposable {
     private FrameBuffer fboWaterRefraction;
     private FrameBuffer fboDepthRefraction;
 
+    private DepthShader depthShader;
+    private ShadowMapShader shadowMapShader;
     private ShadowMapper shadowMapper = null;
 
     protected Vector3 clippingPlaneDisable = new Vector3(0.0f, 0f, 0.0f);
@@ -81,16 +81,10 @@ public class Scene implements Disposable {
 
     private final float distortionEdgeCorrection = 1f;
 
-    private final DepthShader depthShader = new DepthShader();
-    private final ShadowMapShader shadowMapShader = new ShadowMapShader();
-
     public Scene() {
         environment = new MundusEnvironment();
         currentSelection = null;
         terrains = new Array<>();
-
-        depthShader.init();
-        shadowMapShader.init();
 
         cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         cam.position.set(0, 1, -3);
@@ -133,22 +127,6 @@ public class Scene implements Disposable {
         renderWater(delta);
     }
 
-    private void renderShadowMap(float delta) {
-        //TODO: Remove GDX input, testing only
-        if (shadowMapper == null || Gdx.input.isKeyJustPressed(Input.Keys.F5)) {
-            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
-        }
-        DirectionalLight light = LightUtils.getDirectionalLight(environment);
-        if (light == null) return;
-
-        shadowMapper.setCenter(cam.position);
-        shadowMapper.begin(light.direction);
-        batch.begin(shadowMapper.getCam());
-        sceneGraph.renderDepth(delta, clippingPlaneDisable, 0, shadowMapShader);
-        batch.end();
-        shadowMapper.end();
-    }
-
     private void renderObjects(float delta) {
         // Render objects
         batch.begin(cam);
@@ -172,6 +150,22 @@ public class Scene implements Disposable {
 
             Gdx.gl.glDisable(GL20.GL_BLEND);
         }
+    }
+
+    private void renderShadowMap(float delta) {
+        if (shadowMapper == null) {
+            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
+        }
+
+        DirectionalLight light = LightUtils.getDirectionalLight(environment);
+        if (light == null) return;
+
+        shadowMapper.setCenter(cam.position);
+        shadowMapper.begin(light.direction);
+        batch.begin(shadowMapper.getCam());
+        sceneGraph.renderDepth(delta, clippingPlaneDisable, 0, shadowMapShader);
+        batch.end();
+        shadowMapper.end();
     }
 
     private void initFrameBuffers(int width, int height) {
@@ -255,6 +249,14 @@ public class Scene implements Disposable {
 
     public ShadowMapper getShadowMapper() {
         return shadowMapper;
+    }
+
+    public void setDepthShader(DepthShader depthShader) {
+        this.depthShader = depthShader;
+    }
+
+    public void setShadowMapShader(ShadowMapShader shadowMapShader) {
+        this.shadowMapShader = shadowMapShader;
     }
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -159,7 +159,7 @@ public class Scene implements Disposable {
         }
 
         DirectionalLight light = LightUtils.getDirectionalLight(environment);
-        if (light == null) return;
+        if (light == null || !light.castsShadows) return;
 
         shadowMapper.setCenter(cam.position);
         shadowMapper.begin(light.direction);

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -281,7 +281,7 @@ public class Scene implements Disposable {
         if (light == null || shadowResolution == null) return;
 
         if (shadowMapper == null) {
-            shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, cam.far);
+            shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, 800);
         } else {
             shadowMapper.setShadowResolution(shadowResolution);
         }

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -137,9 +137,10 @@ public class Scene implements Disposable {
         if (shadowMapper == null || Gdx.input.isKeyJustPressed(Input.Keys.F5)) {
             setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
         }
+        DirectionalLight light = LightUtils.getDirectionalLight(environment);
 
         shadowMapper.setCenter(cam.position);
-        shadowMapper.begin();
+        shadowMapper.begin(light.direction);
         batch.begin(shadowMapper.getCam());
         sceneGraph.renderDepth(delta, clippingPlaneDisable, 0, shadowMapShader);
         batch.end();
@@ -275,7 +276,7 @@ public class Scene implements Disposable {
         if (light == null) return;
 
         if (shadowMapper == null) {
-            shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, cam.far, light.direction);
+            shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, cam.far);
         } else {
             shadowMapper.setShadowResolution(shadowResolution);
         }

--- a/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/Scene.java
@@ -130,14 +130,12 @@ public class Scene implements Disposable {
         renderShadowMap(delta);
         renderObjects(delta);
         renderWater(delta);
-
     }
 
     private void renderShadowMap(float delta) {
         //TODO: Remove GDX input, testing only
         if (shadowMapper == null || Gdx.input.isKeyJustPressed(Input.Keys.F5)) {
-            shadowMapper = new ShadowMapper(ShadowResolution._4096, (int) cam.viewportWidth , (int) cam.viewportHeight, cam.near, cam.far, LightUtils.getDirectionalLight(environment).direction);
-            environment.shadowMap = shadowMapper;
+            setShadowQuality(ShadowResolution.DEFAULT_SHADOW_RESOLUTION);
         }
 
         shadowMapper.setCenter(cam.position);
@@ -267,12 +265,17 @@ public class Scene implements Disposable {
         initFrameBuffers((int) res.x, (int) res.y);
     }
 
+    /**
+     * Set shadow quality for scenes DirectionalLight.
+     *
+     * @param shadowResolution the shadow resolution to use.
+     */
     public void setShadowQuality(ShadowResolution shadowResolution) {
         DirectionalLight light = LightUtils.getDirectionalLight(environment);
         if (light == null) return;
 
         if (shadowMapper == null) {
-            shadowMapper = new ShadowMapper(shadowResolution, (int) cam.viewportWidth, (int) cam.viewportHeight, cam.near, cam.far, light.direction);
+            shadowMapper = new ShadowMapper(shadowResolution, 512, 512, cam.near, cam.far, light.direction);
         } else {
             shadowMapper.setShadowResolution(shadowResolution);
         }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/BaseLightDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/BaseLightDTO.java
@@ -24,6 +24,7 @@ public class BaseLightDTO {
 
     private float intensity;
     private int color;
+    private boolean castsShadows;
 
     public float getIntensity() {
         return intensity;
@@ -41,4 +42,11 @@ public class BaseLightDTO {
         this.color = color;
     }
 
+    public boolean isCastsShadows() {
+        return castsShadows;
+    }
+
+    public void setCastsShadows(boolean castsShadows) {
+        this.castsShadows = castsShadows;
+    }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/SceneDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/SceneDTO.java
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.commons.dto;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonValue;
+import com.mbrlabs.mundus.commons.shadows.ShadowResolution;
 import com.mbrlabs.mundus.commons.water.WaterResolution;
 
 /**
@@ -42,6 +43,7 @@ public class SceneDTO implements Json.Serializable {
     private float camDirZ = 0;
     private float waterHeight;
     private WaterResolution waterResolution;
+    private ShadowResolution shadowResolution;
 
     public SceneDTO() {
         gameObjects = new Array<>();
@@ -165,6 +167,14 @@ public class SceneDTO implements Json.Serializable {
 
     public String getSkyboxAssetId() {
         return skyboxAssetId;
+    }
+
+    public ShadowResolution getShadowResolution() {
+        return shadowResolution;
+    }
+
+    public void setShadowResolution(ShadowResolution shadowResolution) {
+        this.shadowResolution = shadowResolution;
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/env/lights/BaseLight.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/env/lights/BaseLight.java
@@ -26,6 +26,7 @@ public class BaseLight {
 
     public final Color color = new Color(1, 1, 1, 1);
     public float intensity = 1f;
+    public boolean castsShadows = false;
     public LightType lightType;
 
     public void setColor(Color color) {

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/DirectionalLightConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/DirectionalLightConverter.java
@@ -15,6 +15,7 @@ public class DirectionalLightConverter {
         light.intensity = dto.getIntensity();
         light.color.set(dto.getColor());
         light.direction.set(dto.getDirection());
+        light.castsShadows = dto.isCastsShadows();
 
         return light;
     }
@@ -28,6 +29,7 @@ public class DirectionalLightConverter {
         lightDescriptor.setIntensity(light.intensity);
         lightDescriptor.setColor(Color.rgba8888(light.color));
         lightDescriptor.setDirection(light.direction);
+        lightDescriptor.setCastsShadows(light.castsShadows);
 
         return lightDescriptor;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.scene3d;
 
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.scene3d.components.ClippableComponent;
@@ -132,17 +133,19 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      * @param delta delta time
      * @param clippingPlane the clipping plane to use
      * @param clipHeight clipping height for the clipping plane
+     * @param shader
      */
-    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight) {
+    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
         if (active) {
             for (Component component : this.components) {
-                if (component instanceof ClippableComponent)
-                    ((ClippableComponent)component).renderDepth(delta, clippingPlane, clipHeight);
+                if (component instanceof ClippableComponent) {
+                    ((ClippableComponent) component).renderDepth(delta, clippingPlane, clipHeight, shader);
+                }
             }
 
             if (getChildren() != null) {
                 for (GameObject node : getChildren()) {
-                    node.renderDepth(delta, clippingPlane, clipHeight);
+                    node.renderDepth(delta, clippingPlane, clipHeight, shader);
                 }
             }
         }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SceneGraph.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.commons.scene3d;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.Scene;
@@ -66,11 +67,11 @@ public class SceneGraph {
         }
     }
 
-    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight) {
+    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
         for (GameObject go : root.getChildren()) {
             if (go.findComponentByType(Component.Type.WATER) != null)
                 continue;
-            go.renderDepth(delta, clippingPlane, clipHeight);
+            go.renderDepth(delta, clippingPlane, clipHeight, shader);
         }
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/AbstractComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/AbstractComponent.java
@@ -16,8 +16,8 @@
 
 package com.mbrlabs.mundus.commons.scene3d.components;
 
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
-import com.mbrlabs.mundus.commons.shaders.DepthShader;
 
 /**
  * @author Marcus Brummer
@@ -26,7 +26,7 @@ import com.mbrlabs.mundus.commons.shaders.DepthShader;
 public abstract class AbstractComponent implements Component {
 
     public GameObject gameObject;
-    protected DepthShader depthShader;
+    protected Shader depthShader;
     protected Type type;
 
     public AbstractComponent(GameObject go) {
@@ -34,7 +34,7 @@ public abstract class AbstractComponent implements Component {
     }
 
     @Override
-    public void setDepthShader(DepthShader depthShader) {
+    public void setDepthShader(Shader depthShader) {
         this.depthShader = depthShader;
     }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/AbstractComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/AbstractComponent.java
@@ -26,16 +26,10 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 public abstract class AbstractComponent implements Component {
 
     public GameObject gameObject;
-    protected Shader depthShader;
     protected Type type;
 
     public AbstractComponent(GameObject go) {
         this.gameObject = go;
-    }
-
-    @Override
-    public void setDepthShader(Shader depthShader) {
-        this.depthShader = depthShader;
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ClippableComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ClippableComponent.java
@@ -1,5 +1,6 @@
 package com.mbrlabs.mundus.commons.scene3d.components;
 
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.math.Vector3;
 
 /**
@@ -14,6 +15,7 @@ public interface ClippableComponent {
      * @param delta
      * @param clippingPlane
      * @param clipHeight
+     * @param shader
      */
-    void renderDepth(float delta, Vector3 clippingPlane, float clipHeight);
+    void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader);
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -35,8 +35,6 @@ public interface Component {
 
     void update(float delta);
 
-    void setDepthShader(Shader shader);
-
     Type getType();
 
     void setType(Type type);

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -16,8 +16,8 @@
 
 package com.mbrlabs.mundus.commons.scene3d.components;
 
+import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
-import com.mbrlabs.mundus.commons.shaders.DepthShader;
 
 /**
  * @author Marcus Brummer
@@ -35,7 +35,7 @@ public interface Component {
 
     void update(float delta);
 
-    void setDepthShader(DepthShader shader);
+    void setDepthShader(Shader shader);
 
     Type getType();
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/ModelComponent.java
@@ -99,10 +99,13 @@ public class ModelComponent extends AbstractComponent implements AssetUsage, Cli
     }
 
     @Override
-    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight) {
-        depthShader.setClippingPlane(clippingPlane);
-        depthShader.setClippingHeight(clipHeight);
-        gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment, depthShader);
+    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
+        if (shader instanceof ClippableShader) {
+            ((ClippableShader) shader).setClippingPlane(clippingPlane);
+            ((ClippableShader) shader).setClippingHeight(clipHeight);
+        }
+
+        gameObject.sceneGraph.scene.batch.render(modelInstance, gameObject.sceneGraph.scene.environment, shader);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/TerrainComponent.java
@@ -78,10 +78,13 @@ public class TerrainComponent extends AbstractComponent implements AssetUsage, C
     }
 
     @Override
-    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight) {
-        depthShader.setClippingPlane(clippingPlane);
-        depthShader.setClippingHeight(clipHeight);
-        gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment, depthShader);
+    public void renderDepth(float delta, Vector3 clippingPlane, float clipHeight, Shader shader) {
+        if (shader instanceof ClippableShader) {
+            ((ClippableShader) shader).setClippingPlane(clippingPlane);
+            ((ClippableShader) shader).setClippingHeight(clipHeight);
+        }
+
+        gameObject.sceneGraph.scene.batch.render(terrain.getTerrain(), gameObject.sceneGraph.scene.environment, shader);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/LightShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/LightShader.java
@@ -22,6 +22,11 @@ import com.mbrlabs.mundus.commons.utils.LightUtils;
  */
 public abstract class LightShader extends ClippableShader {
     // ============================ LIGHTS ============================
+    protected final int UNIFORM_SHADOW_BIAS = register(new Uniform("u_shadowBias"));
+    protected final int UNIFORM_USE_SHADOWS = register(new Uniform("u_useShadows"));
+    protected final int UNIFORM_SHADOW_TEXTURE = register(new Uniform("u_shadowTexture"));
+    protected final int UNIFORM_SHADOW_VIEW = register(new Uniform("u_shadowMapProjViewTrans"));
+    protected final int UNIFORM_SHADOW_PCF_OFFSET = register(new Uniform("u_shadowPCFOffset"));
 
     // Specular
     protected final int UNIFORM_USE_SPECULAR = register(new Uniform("u_useSpecular"));
@@ -63,6 +68,8 @@ public abstract class LightShader extends ClippableShader {
     protected int[] UNIFORM_SPOT_LIGHT_ATT_CONSTANT = new int[LightUtils.MAX_SPOT_LIGHTS];
     protected int[] UNIFORM_SPOT_LIGHT_ATT_LINEAR = new int[LightUtils.MAX_SPOT_LIGHTS];
     protected int[] UNIFORM_SPOT_LIGHT_ATT_EXP = new int[LightUtils.MAX_SPOT_LIGHTS];
+
+    private float shadowBias = 1f/255f;
 
     @Override
     public void init(ShaderProgram program, Renderable renderable) {
@@ -162,5 +169,15 @@ public abstract class LightShader extends ClippableShader {
             set(UNIFORM_SPOT_LIGHT_NUM_ACTIVE, 0);
         }
 
+    }
+
+    protected void setShadows(MundusEnvironment env) {
+        if (env.shadowMap != null) {
+            set(UNIFORM_SHADOW_BIAS, shadowBias);
+            set(UNIFORM_USE_SHADOWS, 1);
+            set(UNIFORM_SHADOW_TEXTURE, env.shadowMap.getDepthMap());
+            set(UNIFORM_SHADOW_VIEW, env.shadowMap.getProjViewTrans());
+            set(UNIFORM_SHADOW_PCF_OFFSET,  1.f / (2f * env.shadowMap.getDepthMap().texture.getWidth()));
+        }
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/LightShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/LightShader.java
@@ -172,7 +172,13 @@ public abstract class LightShader extends ClippableShader {
     }
 
     protected void setShadows(MundusEnvironment env) {
-        if (env.shadowMap != null) {
+        DirectionalLight dirLight = LightUtils.getDirectionalLight(env);
+        if (dirLight != null && env.shadowMap != null) {
+            if (!dirLight.castsShadows) {
+                set(UNIFORM_USE_SHADOWS, 0);
+                return;
+            }
+
             set(UNIFORM_SHADOW_BIAS, shadowBias);
             set(UNIFORM_USE_SHADOWS, 1);
             set(UNIFORM_SHADOW_TEXTURE, env.shadowMap.getDepthMap());

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/ModelShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/ModelShader.java
@@ -53,7 +53,7 @@ public class ModelShader extends LightShader {
     protected final int UNIFORM_FOG_GRADIENT = register(new Uniform("u_fogGradient"));
     protected final int UNIFORM_FOG_COLOR = register(new Uniform("u_fogColor"));
 
-    private ShaderProgram program;
+    private final ShaderProgram program;
 
     public ModelShader() {
         program = ShaderUtils.compile(VERTEX_SHADER, FRAGMENT_SHADER, this);
@@ -96,6 +96,7 @@ public class ModelShader extends LightShader {
         final MundusEnvironment env = (MundusEnvironment) renderable.environment;
 
         setLights(env);
+        setShadows(env);
         set(UNIFORM_TRANS_MATRIX, renderable.worldTransform);
 
         // texture uniform

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/ShadowMapShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/ShadowMapShader.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.shaders;
+
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g3d.Renderable;
+import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.graphics.g3d.shaders.BaseShader;
+import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Vector3;
+import com.mbrlabs.mundus.commons.utils.ShaderUtils;
+
+/**
+ * @author James Pooley
+ * @version June 10, 2022
+ */
+public class ShadowMapShader extends BaseShader {
+
+    protected static final String VERTEX_SHADER = "com/mbrlabs/mundus/commons/shaders/shadowmap.vert.glsl";
+    protected static final String FRAGMENT_SHADER = "com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl";
+
+    protected final int UNIFORM_PROJ_VIEW_MATRIX = register(new Uniform("u_projViewWorldTrans"));
+
+    protected ShaderProgram program;
+
+    private final Matrix4 tmpMatrix = new Matrix4();
+    protected final Vector3 center = new Vector3();
+
+    public ShadowMapShader() {
+        program = ShaderUtils.compile(VERTEX_SHADER, FRAGMENT_SHADER, this);
+    }
+
+    @Override
+    public void init() {
+        super.init(program, null);
+    }
+
+    @Override
+    public void begin(Camera camera, RenderContext context) {
+        this.context = context;
+        this.camera = camera;
+        context.begin();
+        //context.setCullFace(GL20.GL_FRONT);
+
+        this.context.setDepthTest(GL20.GL_LEQUAL , 0f, 1f);
+        this.context.setDepthMask(true);
+
+        program.bind();
+    }
+
+    @Override
+    public void render(Renderable renderable) {
+
+        set(UNIFORM_PROJ_VIEW_MATRIX, tmpMatrix.set(camera.combined).mul(renderable.worldTransform));
+
+        // bind attributes, bind mesh & render; then unbinds everything
+        renderable.meshPart.render(program);
+    }
+
+    @Override
+    public void end() {
+        context.end();
+    }
+
+    @Override
+    public void dispose() {
+        program.dispose();
+    }
+
+    @Override
+    public int compareTo(Shader other) {
+        return 0;
+    }
+
+    @Override
+    public boolean canRender(Renderable instance) {
+        return true;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/TerrainShader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/TerrainShader.java
@@ -106,6 +106,7 @@ public class TerrainShader extends LightShader {
         final MundusEnvironment env = (MundusEnvironment) renderable.environment;
 
         setLights(env);
+        setShadows(env);
         setTerrainSplatTextures(renderable);
         set(UNIFORM_TRANS_MATRIX, renderable.worldTransform);
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/model.vert.glsl
@@ -39,6 +39,9 @@ varying vec3 v_worldPos;
 varying float v_clipDistance;
 uniform vec4 u_clipPlane;
 
+uniform mat4 u_shadowMapProjViewTrans;
+varying vec3 v_shadowMapUv;
+
 void main(void) {
     vec4 worldPos = u_transMatrix * vec4(a_position, 1.0);
     v_texCoord0 = a_texCoord0;
@@ -54,6 +57,10 @@ void main(void) {
     // normal for lighting
     v_normal = normalize((u_transMatrix * vec4(a_normal, 0.0)).xyz);
     v_worldPos = worldPos.xyz;
+
+    vec4 spos = u_shadowMapProjViewTrans * worldPos;
+    v_shadowMapUv.xy = (spos.xy / spos.w) * 0.5 + 0.5;
+    v_shadowMapUv.z = min(spos.z * 0.5 + 0.5, 0.998);
 
     // =================================================================
     //                          /Lighting

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#ifdef GL_ES
+precision highp float;
+#endif
+
 vec4 EncodeFloatRGBA( float v ) {
     vec4 enc = vec4(1.0, 255.0, 65025.0, 16581375.0) * v;
     enc = fract(enc);

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+vec4 EncodeFloatRGBA( float v ) {
+    vec4 enc = vec4(1.0, 255.0, 65025.0, 16581375.0) * v;
+    enc = fract(enc);
+    enc -= enc.yzww * vec4(1.0/255.0,1.0/255.0,1.0/255.0,0.0);
+    return enc;
+}
+
+void main()
+{
+    // Encode the depth into RGBA values, for later decoding in other shaders, to improve precision
+    gl_FragColor = EncodeFloatRGBA(gl_FragCoord.z);
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/shadowmap.vert.glsl
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+attribute vec3 a_position;
+uniform mat4 u_projViewWorldTrans;
+
+void main() {
+    gl_Position = u_projViewWorldTrans * vec4(a_position, 1.0);
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/terrain.vert.glsl
@@ -46,10 +46,17 @@ varying vec3 v_pos;
 varying float v_clipDistance;
 uniform vec4 u_clipPlane;
 
+uniform mat4 u_shadowMapProjViewTrans;
+varying vec3 v_shadowMapUv;
+
 void main(void) {
     // position
     vec4 worldPos = u_transMatrix * vec4(a_position, 1.0);
     gl_Position = u_projViewMatrix * worldPos;
+
+    vec4 spos = u_shadowMapProjViewTrans * worldPos;
+    v_shadowMapUv.xy = (spos.xy / spos.w) * 0.5 + 0.5;
+    v_shadowMapUv.z = min(spos.z * 0.5 + 0.5, 0.998);
 
     // normal for lighting
     v_normal = normalize((u_transMatrix * vec4(a_normal, 0.0)).xyz);

--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/water.vert.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/water.vert.glsl
@@ -19,9 +19,13 @@ varying vec4 v_clipSpace;
 varying vec3 v_toCameraVector;
 varying vec3 v_worldPos;
 
+varying vec3 v_shadowMapUv;
+
 void main() {
     vec4 worldPos = u_transMatrix * vec4(a_position, 1.0);
     v_worldPos = worldPos.xyz;
+
+    v_shadowMapUv = vec3(0.0);
 
     v_clipSpace = u_projViewMatrix * worldPos;
     gl_Position = v_clipSpace;

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
@@ -62,10 +62,10 @@ public class ShadowMapper implements ShadowMap {
         this.viewportWidth = viewportWidth;
         this.viewportHeight = viewportHeight;
         this.near = near;
-        this.far = far * .2f;
+        this.far = far;
 
-        fbo = new NestableFrameBuffer(Pixmap.Format.RGB888, textureWidth, textureHeight, true);
-        cam = new OrthographicCamera(viewportWidth, viewportHeight);
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
+        cam = new OrthographicCamera(this.viewportWidth, this.viewportHeight);
         cam.near = near;
         cam.far = this.far;
 
@@ -119,7 +119,7 @@ public class ShadowMapper implements ShadowMap {
         this.textureWidth = (int) res.x;
         this.textureHeight = (int) res.y;
         fbo.dispose();
-        fbo = new NestableFrameBuffer(Pixmap.Format.RGB888, textureWidth, textureHeight, true);
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.environment.ShadowMap;
@@ -28,6 +29,7 @@ import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
+import com.mbrlabs.mundus.commons.env.lights.DirectionalLight;
 import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 
 /**
@@ -44,7 +46,6 @@ public class ShadowMapper implements ShadowMap {
     protected ShadowResolution shadowResolution;
     protected FrameBuffer fbo;
     protected Camera cam;
-    protected Vector3 direction;
 
     int textureWidth;
     int textureHeight;
@@ -53,7 +54,7 @@ public class ShadowMapper implements ShadowMap {
     float near;
     float far;
 
-    public ShadowMapper(ShadowResolution resolution, int viewportWidth, int viewportHeight, float near, float far, Vector3 direction) {
+    public ShadowMapper(ShadowResolution resolution, int viewportWidth, int viewportHeight, float near, float far) {
         Vector2 res = resolution.getResolutionValues();
         this.shadowResolution = resolution;
         this.textureWidth = (int) res.x;
@@ -61,23 +62,22 @@ public class ShadowMapper implements ShadowMap {
         this.viewportWidth = viewportWidth;
         this.viewportHeight = viewportHeight;
         this.near = near;
-        this.far = far;
-        this.direction = direction;
+        this.far = far * .2f;
 
-        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGB888, textureWidth, textureHeight, true);
         cam = new OrthographicCamera(viewportWidth, viewportHeight);
         cam.near = near;
-        cam.far = far;
+        cam.far = this.far;
 
         textureDesc = new TextureDescriptor();
         textureDesc.minFilter = textureDesc.magFilter = Texture.TextureFilter.Nearest;
         textureDesc.uWrap = textureDesc.vWrap = Texture.TextureWrap.ClampToEdge;
     }
 
-    public void begin() {
+    public void begin(Vector3 lightDirection) {
         float halfDepth = cam.near + 0.5f * (cam.far - cam.near);
-        cam.direction.set(direction).nor();
-        cam.position.set(direction).scl(-halfDepth).add(center);
+        cam.direction.set(lightDirection).nor();
+        cam.position.set(lightDirection).scl(-halfDepth).add(center);
         cam.normalizeUp();
         cam.update();
 
@@ -109,10 +109,6 @@ public class ShadowMapper implements ShadowMap {
         return cam;
     }
 
-    public void setDirection(Vector3 direction) {
-        this.direction = direction;
-    }
-
     public ShadowResolution getShadowResolution() {
         return shadowResolution;
     }
@@ -123,7 +119,7 @@ public class ShadowMapper implements ShadowMap {
         this.textureWidth = (int) res.x;
         this.textureHeight = (int) res.y;
         fbo.dispose();
-        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGB888, textureWidth, textureHeight, true);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.graphics.g3d.environment.ShadowMap;
 import com.badlogic.gdx.graphics.g3d.utils.TextureDescriptor;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
 
@@ -37,11 +38,13 @@ import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
  */
 public class ShadowMapper implements ShadowMap {
 
+    protected final TextureDescriptor textureDesc;
+    protected final Vector3 center = new Vector3();
+
+    protected ShadowResolution shadowResolution;
     protected FrameBuffer fbo;
     protected Camera cam;
     protected Vector3 direction;
-    protected final TextureDescriptor textureDesc;
-    protected final Vector3 center = new Vector3();
 
     int textureWidth;
     int textureHeight;
@@ -50,9 +53,11 @@ public class ShadowMapper implements ShadowMap {
     float near;
     float far;
 
-    public ShadowMapper(int textureWidth, int textureHeight, int viewportWidth, int viewportHeight, float near, float far, Vector3 direction) {
-        this.textureWidth = textureWidth;
-        this.textureHeight = textureHeight;
+    public ShadowMapper(ShadowResolution resolution, int viewportWidth, int viewportHeight, float near, float far, Vector3 direction) {
+        Vector2 res = resolution.getResolutionValues();
+        this.shadowResolution = resolution;
+        this.textureWidth = (int) res.x;
+        this.textureHeight = (int) res.y;
         this.viewportWidth = viewportWidth;
         this.viewportHeight = viewportHeight;
         this.near = near;
@@ -106,6 +111,19 @@ public class ShadowMapper implements ShadowMap {
 
     public void setDirection(Vector3 direction) {
         this.direction = direction;
+    }
+
+    public ShadowResolution getShadowResolution() {
+        return shadowResolution;
+    }
+
+    public void setShadowResolution(ShadowResolution resolution) {
+        Vector2 res = resolution.getResolutionValues();
+        this.shadowResolution = resolution;
+        this.textureWidth = (int) res.x;
+        this.textureHeight = (int) res.y;
+        fbo.dispose();
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
     }
 
     @Override

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.shadows;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.environment.ShadowMap;
+import com.badlogic.gdx.graphics.g3d.utils.TextureDescriptor;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Vector3;
+import com.mbrlabs.mundus.commons.utils.NestableFrameBuffer;
+
+/**
+ * Wrapper around an FBO for shadow mapping, based on DirectionalShadowLight from libGDX and gdx-gltf
+ *
+ * @author James Pooley
+ * @version June 10, 2022
+ */
+public class ShadowMapper implements ShadowMap {
+
+    protected FrameBuffer fbo;
+    protected Camera cam;
+    protected Vector3 direction;
+    protected final TextureDescriptor textureDesc;
+    protected final Vector3 center = new Vector3();
+
+    int textureWidth;
+    int textureHeight;
+    int viewportWidth;
+    int viewportHeight;
+    float near;
+    float far;
+
+    public ShadowMapper(int textureWidth, int textureHeight, int viewportWidth, int viewportHeight, float near, float far, Vector3 direction) {
+        this.textureWidth = textureWidth;
+        this.textureHeight = textureHeight;
+        this.viewportWidth = viewportWidth;
+        this.viewportHeight = viewportHeight;
+        this.near = near;
+        this.far = far;
+        this.direction = direction;
+
+        fbo = new NestableFrameBuffer(Pixmap.Format.RGBA8888, textureWidth, textureHeight, true);
+        cam = new OrthographicCamera(viewportWidth, viewportHeight);
+        cam.near = near;
+        cam.far = far;
+
+        textureDesc = new TextureDescriptor();
+        textureDesc.minFilter = textureDesc.magFilter = Texture.TextureFilter.Nearest;
+        textureDesc.uWrap = textureDesc.vWrap = Texture.TextureWrap.ClampToEdge;
+    }
+
+    public void begin() {
+        float halfDepth = cam.near + 0.5f * (cam.far - cam.near);
+        cam.direction.set(direction).nor();
+        cam.position.set(direction).scl(-halfDepth).add(center);
+        cam.normalizeUp();
+        cam.update();
+
+        final int w = fbo.getWidth();
+        final int h = fbo.getHeight();
+        fbo.begin();
+        Gdx.gl.glViewport(0, 0, w, h);
+        Gdx.gl.glClearColor(1, 1, 1, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+        Gdx.gl.glEnable(GL20.GL_SCISSOR_TEST);
+        Gdx.gl.glScissor(1, 1, w - 2, h - 2);
+    }
+
+    public void end(){
+        Gdx.gl.glDisable(GL20.GL_SCISSOR_TEST);
+        fbo.end();
+    }
+
+    public void setCenter(Vector3 center) {
+        this.center.set(center);
+    }
+
+
+    public FrameBuffer getFbo() {
+        return fbo;
+    }
+
+    public Camera getCam() {
+        return cam;
+    }
+
+    public void setDirection(Vector3 direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    public Matrix4 getProjViewTrans() {
+        return cam.combined;
+    }
+
+    @Override
+    public TextureDescriptor getDepthMap() {
+        textureDesc.texture = fbo.getColorBufferTexture();
+        return textureDesc;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowResolution.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowResolution.java
@@ -3,6 +3,9 @@ package com.mbrlabs.mundus.commons.shadows;
 import com.badlogic.gdx.math.Vector2;
 
 /**
+ * Represents options for Shadow Mapping texture resolution. Higher resolutions will look
+ * sharper but use more resources.
+ *
  * @author James Pooley
  * @version June 12, 2022
  */

--- a/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowResolution.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shadows/ShadowResolution.java
@@ -1,0 +1,53 @@
+package com.mbrlabs.mundus.commons.shadows;
+
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * @author James Pooley
+ * @version June 12, 2022
+ */
+public enum ShadowResolution {
+    _512("512x512"),
+    _1024("1024x1024"),
+    _2048("2048x2048"),
+    _4096("4096x4096");
+
+    public static final ShadowResolution DEFAULT_SHADOW_RESOLUTION = _2048;
+    private final String value;
+
+    ShadowResolution(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Vector2 getResolutionValues() {
+        if (this == _1024) {
+            return new Vector2(1024, 1024);
+        }
+        if (this == _512) {
+            return new Vector2(512, 512);
+        }
+        if (this == _2048) {
+            return new Vector2(2048, 2048);
+        }
+        if (this == _4096) {
+            return new Vector2(4096, 4096);
+        }
+
+        return new Vector2(2048, 2048);
+    }
+
+    public static ShadowResolution valueFromString(String string) {
+        for (ShadowResolution res : values()) {
+            if (res.value.equals(string)) {
+                return res;
+            }
+        }
+
+        return DEFAULT_SHADOW_RESOLUTION;
+    }
+
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/LightUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/LightUtils.java
@@ -3,11 +3,7 @@ package com.mbrlabs.mundus.commons.utils;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.env.MundusEnvironment;
-import com.mbrlabs.mundus.commons.env.lights.LightType;
-import com.mbrlabs.mundus.commons.env.lights.PointLight;
-import com.mbrlabs.mundus.commons.env.lights.PointLightsAttribute;
-import com.mbrlabs.mundus.commons.env.lights.SpotLight;
-import com.mbrlabs.mundus.commons.env.lights.SpotLightsAttribute;
+import com.mbrlabs.mundus.commons.env.lights.*;
 
 /**
  * Utilities class for lighting.
@@ -19,6 +15,18 @@ public class LightUtils {
 
     public static final int MAX_POINT_LIGHTS = 12;
     public static final int MAX_SPOT_LIGHTS = 12;
+
+    /**
+     * Return the first Directional Light. Currently only one Directional Light is supported.
+     */
+    public static DirectionalLight getDirectionalLight(Environment env) {
+        DirectionalLightsAttribute dirLightAttribs = env.get(DirectionalLightsAttribute.class, DirectionalLightsAttribute.Type);
+        Array<DirectionalLight> dirLights = dirLightAttribs.lights;
+        if (dirLights != null && dirLights.size > 0) {
+            return dirLights.first();
+        }
+        return null;
+    }
 
     public static Array<PointLight> getPointLights(Environment env) {
         PointLightsAttribute attr = env.get(PointLightsAttribute.class, PointLightsAttribute.Type);

--- a/commons/src/main/commons.gwt.xml
+++ b/commons/src/main/commons.gwt.xml
@@ -14,6 +14,7 @@
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.FogDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.dto.ModelComponentDTO" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.water.WaterResolution" />
+    <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.shadows.ShadowResolution" />
     <extend-configuration-property name="gdx.reflect.include" value="com.mbrlabs.mundus.commons.env.lights.LightType" />
 
 </module>

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -5,6 +5,7 @@
 - Added new Gizmo feature for displaying decal Icons over objects like Light sources.
 - Added normal mapping for terrains and models
 - Added new profiling bar with GL profiler statistics
+- Added experimental basic directional light shadows
 - Update water shader to fade out water foam over distance, to minimize ugly 1 pixel white lines from a distance.
 - Fix broken checkbox to set game objects to active or inactive
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Mundus.kt
@@ -181,7 +181,7 @@ object Mundus {
                 addIcon(Fa.CIRCLE_O).addIcon(Fa.CIRCLE).addIcon(Fa.MINUS).addIcon(Fa.CARET_DOWN).
                 addIcon(Fa.CARET_UP).addIcon(Fa.TIMES).addIcon(Fa.SORT).addIcon(Fa.HASHTAG).
                 addIcon(Fa.PAINT_BRUSH).addIcon(Fa.STAR).addIcon(Fa.REFRESH).addIcon(Fa.EXPAND).
-                addIcon(Fa.ARROWS_ALT).addIcon(Fa.EYE).addIcon(Fa.EYE_SLASH).build()
+                addIcon(Fa.ARROWS_ALT).addIcon(Fa.EYE).addIcon(Fa.EYE_SLASH).addIcon(Fa.INFO_CIRCLE).build()
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/ModelComponentConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/ModelComponentConverter.java
@@ -48,7 +48,6 @@ public class ModelComponentConverter {
 
         PickableModelComponent component = new PickableModelComponent(go, Shaders.INSTANCE.getModelShader());
         component.setModel(model, false);
-        component.setDepthShader(Shaders.INSTANCE.getDepthShader());
 
         for (String g3dbMatID : dto.getMaterials().keySet()) {
             String uuid = dto.getMaterials().get(g3dbMatID);

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/SceneConverter.java
@@ -65,6 +65,8 @@ public class SceneConverter {
         dto.setWaterResolution(scene.waterResolution);
         dto.setWaterHeight(scene.waterHeight);
 
+        dto.setShadowResolution(scene.getShadowMapper().getShadowResolution());
+
         // camera
         dto.setCamPosX(scene.cam.position.x);
         dto.setCamPosY(scene.cam.position.y);

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/TerrainComponentConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/TerrainComponentConverter.java
@@ -49,7 +49,6 @@ public class TerrainComponentConverter {
         terrain.getTerrain().transform = go.getTransform();
         PickableTerrainComponent terrainComponent = new PickableTerrainComponent(go, Shaders.INSTANCE.getTerrainShader());
         terrainComponent.setTerrain(terrain);
-        terrainComponent.setDepthShader(Shaders.INSTANCE.getDepthShader());
 
         return terrainComponent;
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -433,6 +433,8 @@ public class ProjectManager implements Disposable {
         scene.setShadowMapShader(Shaders.INSTANCE.getShadowMapShader());
         scene.setDepthShader(Shaders.INSTANCE.getDepthShader());
 
+        scene.setShadowQuality(sceneDTO.getShadowResolution());
+
         SceneGraph sceneGraph = scene.sceneGraph;
         for (GameObject go : sceneGraph.getGameObjects()) {
             initGameObject(context, go);

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -430,6 +430,9 @@ public class ProjectManager implements Disposable {
 
         scene.batch = modelBatch;
 
+        scene.setShadowMapShader(Shaders.INSTANCE.getShadowMapShader());
+        scene.setDepthShader(Shaders.INSTANCE.getDepthShader());
+
         SceneGraph sceneGraph = scene.sceneGraph;
         for (GameObject go : sceneGraph.getGameObjects()) {
             initGameObject(context, go);

--- a/editor/src/main/com/mbrlabs/mundus/editor/shader/Shaders.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/shader/Shaders.kt
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.glutils.ShaderProgram
 import com.badlogic.gdx.utils.Disposable
 import com.mbrlabs.mundus.commons.shaders.DepthShader
 import com.mbrlabs.mundus.commons.shaders.ModelShader
+import com.mbrlabs.mundus.commons.shaders.ShadowMapShader
 import com.mbrlabs.mundus.commons.shaders.SkyboxShader
 import com.mbrlabs.mundus.commons.shaders.WaterShader
 import com.mbrlabs.mundus.editor.terrain.EditorTerrainShader
@@ -39,6 +40,7 @@ object Shaders : Disposable {
     val skyboxShader: SkyboxShader
     val pickerShader: PickerShader
     val depthShader: DepthShader
+    val shadowMapShader: ShadowMapShader
 
     init {
         ShaderProgram.pedantic = false
@@ -56,6 +58,8 @@ object Shaders : Disposable {
         pickerShader.init()
         depthShader = DepthShader()
         depthShader.init()
+        shadowMapShader = ShadowMapShader()
+        shadowMapShader.init()
     }
 
     override fun dispose() {

--- a/editor/src/main/com/mbrlabs/mundus/editor/tools/ModelPlacementTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/tools/ModelPlacementTool.java
@@ -118,7 +118,6 @@ public class ModelPlacementTool extends Tool {
 
             PickableModelComponent modelComponent = new PickableModelComponent(modelGo, Shaders.INSTANCE.getModelShader());
             modelComponent.setShader(getShader());
-            modelComponent.setDepthShader(Shaders.INSTANCE.getDepthShader());
             modelComponent.setModel(model, true);
             modelComponent.encodeRaypickColorId();
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
@@ -22,6 +22,7 @@ import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.widgets.ColorPickerField
 import com.mbrlabs.mundus.editor.ui.widgets.ImprovedSlider
+import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
 
 /**
  * @author James Pooley
@@ -99,17 +100,20 @@ class  DirectionalLightsDialog : BaseDialog("Directional Light"), ProjectChanged
     }
 
     private fun addShadowSection() {
-        root.add(VisLabel("Shadow Settings")).colspan(2).left().row()
+        val shadowLabel = ToolTipLabel("Shadow Settings", "Experimental for now." +
+                " Only a single pass shadow map with limited range.")
+        root.add(shadowLabel).colspan(2).left().row()
         root.addSeparator().colspan(2).row()
 
         // Settings
         val shadowSettingsTable = VisTable()
-        val enableLabel = VisLabel("Cast Dynamic Shadows: ")
+        val enableLabel = ToolTipLabel("Cast Dynamic Shadows: ", "Enables shadow mapping.")
         shadowSettingsTable.defaults().padBottom(5f).padLeft(6f).padRight(6f)
         shadowSettingsTable.add(enableLabel).left().padBottom(10f)
         shadowSettingsTable.add(castShadows).left().padBottom(10f).left().row()
 
-        val resolutionLabel = VisLabel("Shadow Resolution: ")
+        val resolutionLabel = ToolTipLabel("Shadow Resolution: ", "Higher resolution results in better " +
+                "shadows at the cost of performance.")
         val selectorsTable = VisTable(true)
         shadowResSelectBox = VisSelectBox<String>()
         shadowResSelectBox.setItems(
@@ -122,14 +126,6 @@ class  DirectionalLightsDialog : BaseDialog("Directional Light"), ProjectChanged
 
         shadowSettingsTable.add(resolutionLabel).left().padBottom(10f)
         shadowSettingsTable.add(selectorsTable).padBottom(10f)
-
-        var tip = "Enables shadow mapping."
-        Tooltip.Builder(tip).target(enableLabel).build()
-        Tooltip.Builder(tip).target(castShadows).build()
-
-        tip = "Sets shadow texture resolution. Higher resolutions look better but uses more resources."
-        Tooltip.Builder(tip).target(resolutionLabel).build()
-        Tooltip.Builder(tip).target(shadowResSelectBox).build()
 
         root.add(shadowSettingsTable).left().row()
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
@@ -5,7 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.InputEvent
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener
-import com.kotcrab.vis.ui.widget.Tooltip
 import com.kotcrab.vis.ui.widget.VisCheckBox
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisSelectBox
@@ -203,6 +202,8 @@ class  DirectionalLightsDialog : BaseDialog("Directional Light"), ProjectChanged
                 light?.intensity = DirectionalLight.DEFAULT_INTENSITY
                 light?.direction?.set(DirectionalLight.DEFAULT_DIRECTION)
 
+                light?.castsShadows = false
+                projectManager.current().currScene.shadowMapper.shadowResolution = ShadowResolution.DEFAULT_SHADOW_RESOLUTION
                 resetValues()
             }
         })

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/FaLabel.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/FaLabel.java
@@ -27,11 +27,16 @@ import com.mbrlabs.mundus.editor.utils.Colors;
  */
 public class FaLabel extends VisLabel {
 
-    private final static LabelStyle style = new LabelStyle();
+    public final static LabelStyle style = new LabelStyle();
     static {
         style.font = Mundus.INSTANCE.getFa();
-        style.fontColor = Color.WHITE;
         style.fontColor = Colors.INSTANCE.getTEAL();
+    }
+
+    public final static LabelStyle styleActive = new LabelStyle();
+    static {
+        styleActive.font = Mundus.INSTANCE.getFa();
+        styleActive.fontColor = Color.WHITE;
     }
 
     public FaLabel(String text) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/ToolTipLabel.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/ToolTipLabel.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.ui.widgets
+
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.InputEvent
+import com.badlogic.gdx.scenes.scene2d.InputListener
+import com.badlogic.gdx.utils.Align
+import com.kotcrab.vis.ui.widget.Tooltip
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.kotcrab.vis.ui.widget.VisTable
+import com.mbrlabs.mundus.editor.utils.Fa
+
+/**
+ * A table containing both a label and tool tip icon.
+ *
+ * @author James Pooley
+ * @version July 05, 2022
+ */
+class ToolTipLabel(val label: String, toolTipText: String) : VisTable() {
+    var fieldLabel = VisLabel(label)
+    var fieldInfo = FaLabel(Fa.INFO_CIRCLE)
+
+    init {
+        defaults().padRight(4f)
+        add(fieldLabel, fieldInfo)
+        Tooltip.Builder(toolTipText, Align.left).target(fieldInfo).build()
+
+        fieldInfo.addListener(object : InputListener() {
+            override fun enter(event: InputEvent?, x: Float, y: Float, pointer: Int, fromActor: Actor?) {
+                super.enter(event, x, y, pointer, fromActor)
+                fieldInfo.style = FaLabel.styleActive
+            }
+
+            override fun exit(event: InputEvent?, x: Float, y: Float, pointer: Int, toActor: Actor?) {
+                super.exit(event, x, y, pointer, toActor)
+                fieldInfo.style = FaLabel.style
+            }
+        })
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/TerrainUtils.kt
@@ -41,7 +41,6 @@ fun createTerrainGO(sg: SceneGraph, shader: TerrainShader, goID: Int, goName: St
     terrainComponent.terrain = terrain
     terrainGO.components.add(terrainComponent)
     terrainComponent.shader = shader
-    terrainComponent.setDepthShader(Shaders.depthShader)
     terrainComponent.encodeRaypickColorId()
 
     return terrainGO

--- a/gdx-runtime/src/com/mbrlabs/mundus.gwt.xml
+++ b/gdx-runtime/src/com/mbrlabs/mundus.gwt.xml
@@ -14,6 +14,8 @@
     <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/water.vert.glsl" />
     <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/depth.frag.glsl" />
     <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/depth.vert.glsl" />
+    <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/shadowmap.frag.glsl" />
+    <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/shadowmap.vert.glsl" />
     <extend-configuration-property name="gdx.files.classpath" value="com/mbrlabs/mundus/commons/shaders/light.glsl" />
 
 </module>

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/SceneLoader.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/SceneLoader.java
@@ -65,6 +65,9 @@ public class SceneLoader {
             scene.setSkybox(skyboxAsset, mundus.getShaders().getSkyboxShader());
         }
 
+        scene.setShadowMapShader(mundus.getShaders().getShadowMapShader());
+        scene.setDepthShader(mundus.getShaders().getDepthShader());
+
         SceneGraph sceneGraph = scene.sceneGraph;
         for (GameObject go : sceneGraph.getGameObjects()) {
             initGameObject(go);

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/Shaders.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/Shaders.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.runtime;
 
 import com.mbrlabs.mundus.commons.shaders.DepthShader;
 import com.mbrlabs.mundus.commons.shaders.ModelShader;
+import com.mbrlabs.mundus.commons.shaders.ShadowMapShader;
 import com.mbrlabs.mundus.commons.shaders.SkyboxShader;
 import com.mbrlabs.mundus.commons.shaders.TerrainShader;
 import com.mbrlabs.mundus.commons.shaders.WaterShader;
@@ -29,6 +30,7 @@ public class Shaders {
     private final WaterShader waterShader;
     private final SkyboxShader skyboxShader;
     private final DepthShader depthShader;
+    private final ShadowMapShader shadowMapShader;
 
     public Shaders() {
         modelShader = new ModelShader();
@@ -41,6 +43,8 @@ public class Shaders {
         skyboxShader.init();
         depthShader = new DepthShader();
         depthShader.init();
+        shadowMapShader = new ShadowMapShader();
+        shadowMapShader.init();
     }
 
     public ModelShader getModelShader() {
@@ -61,5 +65,9 @@ public class Shaders {
 
     public DepthShader getDepthShader() {
         return depthShader;
+    }
+
+    public ShadowMapShader getShadowMapShader() {
+        return shadowMapShader;
     }
 }

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/ModelComponentConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/ModelComponentConverter.java
@@ -38,7 +38,6 @@ public class ModelComponentConverter {
                                          Shaders shaders, AssetManager assetManager) {
         ModelComponent mc = new ModelComponent(gameObject, shaders.getModelShader());
         mc.setModel((ModelAsset) assetManager.findAssetByID(modelComponentDTO.getModelID()), false);
-        mc.setDepthShader(shaders.getDepthShader());
 
         for(Map.Entry<String, String> entry : modelComponentDTO.getMaterials().entrySet()) {
             mc.getMaterials().put(entry.getKey(), (MaterialAsset) assetManager.findAssetByID(entry.getValue()));

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/SceneConverter.java
@@ -67,6 +67,8 @@ public class SceneConverter {
 
         scene.waterHeight = dto.getWaterHeight();
 
+        scene.setShadowQuality(dto.getShadowResolution());
+
         // scene graph
         scene.sceneGraph = new SceneGraph(scene);
         for (GameObjectDTO descriptor : dto.getGameObjects()) {

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/TerrainComponentConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/TerrainComponentConverter.java
@@ -35,7 +35,6 @@ public class TerrainComponentConverter {
                                            Shaders shaders, AssetManager assetManager) {
         TerrainComponent tc = new TerrainComponent(gameObject, shaders.getTerrainShader());
         tc.setTerrain((TerrainAsset) assetManager.findAssetByID(terrainComponentDTO.getTerrainID()));
-        tc.setDepthShader(shaders.getDepthShader());
 
         return tc;
     }


### PR DESCRIPTION
Adds experimental basic shadow mapping based on existing libGDX shadow mapping with limited range. I have some working branches with cascaded shadow mapping but I have not worked it out fully yet so for now we have basic shadows.

- [x] Test Windows/Linux(WSL)/HTML/Android
- [x] update CHANGES files