### PR TITLE
Add global UI scaling options for high resolution screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ android/libs/armeabi-v7a/
 android/libs/x86/
 android/gen/
 .idea/
+.run/
 *.ipr
 *.iws
 *.iml

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -25,6 +25,7 @@ import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.graphics.g3d.ModelBatch
 import com.badlogic.gdx.graphics.g3d.ModelInstance
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.badlogic.gdx.utils.viewport.ScreenViewport
 import com.mbrlabs.mundus.commons.utils.DebugRenderer
 import com.mbrlabs.mundus.commons.utils.ShaderUtils
 import com.mbrlabs.mundus.editor.core.project.ProjectAlreadyImportedException
@@ -111,6 +112,8 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
             context = createDefaultProject()
             projectManager.startAsyncProjectLoad(context!!.path, context)
         }
+
+        UI.updateScale()
 
         guiCamera = OrthographicCamera()
         guiCamera.setToOrtho(
@@ -275,6 +278,7 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
     }
 
     override fun resize(width: Int, height: Int) {
+//        UI.viewport.update((width*UI.scale).toInt(),(height*UI.scale).toInt(), true)
         UI.viewport.update(width, height, true)
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/preferences/MundusPreferencesManager.kt
@@ -19,6 +19,7 @@ class MundusPreferencesManager(preferencesKey: String) : PreferencesManager {
         const val GLOB_LINE_WIDTH_SELECTION = "line-width-selection"
         const val GLOB_LINE_WIDTH_WIREFRAME = "line-width-wireframe"
         const val GLOB_LINE_WIDTH_HELPER_LINE = "line-width-helper-line"
+        const val GLOB_UI_SCALE = "ui-scale"
 
         // Debug renderer settings
         const val GLOB_BOOL_DEBUG_RENDERER_ON = "debug-renderer-on"
@@ -28,6 +29,7 @@ class MundusPreferencesManager(preferencesKey: String) : PreferencesManager {
         // Default values for global prefs
         const val GLOB_RIGHT_SELECT_BUTTON_DEFAULT_VALUE = true
         const val GLOB_LINE_WIDTH_DEFAULT_VALUE = 1.0f
+        const val GLOB_UI_SCALE_DEFAULT_VALUE = 1.0f
 
         /** Keys for project specific prefs **/
         const val PROJ_LAST_DIR = "lastDirectoryOpened"

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/UI.kt
@@ -62,6 +62,9 @@ object UI : Stage(ScreenViewport()) {
     const val PAD_SIDE: Float = 5f
     const val PAD_SIDE_X2: Float = PAD_SIDE * 2
 
+    @kotlin.jvm.JvmField
+    var scale: Float= 1f
+
     var isFullScreenRender = false
 
     // reusable ui elements
@@ -225,5 +228,13 @@ object UI : Stage(ScreenViewport()) {
             globalPrefManager.set(MundusPreferencesManager.GLOB_MUNDUS_VERSION, VERSION)
             showDialog(versionDialog)
         }
+    }
+
+    fun updateScale() {
+        scale = globalPrefManager.getFloat(MundusPreferencesManager.GLOB_UI_SCALE, 1f)
+        var tempViewport=UI.viewport as ScreenViewport
+        tempViewport.unitsPerPixel=1/UI.scale
+
+        UI.viewport.update(Gdx.graphics.width, Gdx.graphics.height, true)
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/AppearanceSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/AppearanceSettingsTable.kt
@@ -36,6 +36,7 @@ class AppearanceSettingsTable : BaseSettingsTable() {
     private val selectionLineWidth = VisTextField("0")
     private val wireframeLineWidth = VisTextField("0")
     private val helperLineWidth = VisTextField("0")
+    private val globalUIScale = VisTextField("0")
 
     init {
         top().left()
@@ -45,6 +46,7 @@ class AppearanceSettingsTable : BaseSettingsTable() {
         selectionLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
         wireframeLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
         helperLineWidth.textFieldFilter = FloatDigitsOnlyFilter(false)
+        globalUIScale.textFieldFilter = FloatDigitsOnlyFilter(false)
 
         add(VisLabel("Appearance Settings")).left().row()
         addSeparator().padBottom(10f)
@@ -58,6 +60,9 @@ class AppearanceSettingsTable : BaseSettingsTable() {
         add(VisLabel("Helper line width")).row()
         add(helperLineWidth).padBottom(4f).row()
 
+        add(VisLabel("Global UI scale")).row()
+        add(globalUIScale).padBottom(4f).row()
+
         loadValues()
     }
 
@@ -65,6 +70,7 @@ class AppearanceSettingsTable : BaseSettingsTable() {
         selectionLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_SELECTION, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
         wireframeLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_WIREFRAME, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
         helperLineWidth.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_LINE_WIDTH_HELPER_LINE, MundusPreferencesManager.GLOB_LINE_WIDTH_DEFAULT_VALUE).toString()
+        globalUIScale.text = globalPreferencesManager.getFloat(MundusPreferencesManager.GLOB_UI_SCALE, MundusPreferencesManager.GLOB_UI_SCALE_DEFAULT_VALUE).toString()
     }
 
     override fun onSave() {
@@ -84,6 +90,14 @@ class AppearanceSettingsTable : BaseSettingsTable() {
             globalPreferencesManager.set(MundusPreferencesManager.GLOB_LINE_WIDTH_HELPER_LINE, helperLineWidth.text.toFloat())
         } catch (ex : NumberFormatException) {
             Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + helperLineWidth.name))
+        }
+
+        try {
+            globalPreferencesManager.set(MundusPreferencesManager.GLOB_UI_SCALE, globalUIScale.text.toFloat())
+
+            UI.updateScale()
+        } catch (ex : NumberFormatException) {
+            Mundus.postEvent(LogEvent(LogType.ERROR,"Error parsing field " + globalUIScale.name))
         }
 
         UI.toaster.success("Settings saved")

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/RenderWidget.java
@@ -73,7 +73,9 @@ public class RenderWidget extends Widget {
         final int height = (int) getHeight();
 
         // apply widget viewport
-        viewport.setScreenBounds((int) vec.x, (int) vec.y, width, height);
+        viewport.setScreenBounds(
+                (int) (vec.x * UI.scale), (int) (vec.y * UI.scale),
+                (int) (width * UI.scale), (int) (height * UI.scale));
         viewport.setWorldSize(width * viewport.getUnitsPerPixel(), height * viewport.getUnitsPerPixel());
         viewport.apply();
 


### PR DESCRIPTION
when using a 4k monitor, the ui of Mundus will be too small and affecting user experience. Added global scaling function achieved by modifying the unitsPerPixel member variable of ScreenViewport, defect of this fix is that the graphics will have bigger pixel, and when the scale is set to non integer value it will be even more ugly, so is only a temporary fix.

Effects when Using this new options and global UI scale is set to 2.0 on 1920p monitor: 
![image](https://github.com/JamesTKhan/Mundus/assets/62501730/1eb1d56f-3b39-485e-aa7e-c6eed1db13d2)
