### PR TITLE
Custom asset via plugin

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetManager.java
@@ -396,6 +396,9 @@ public class AssetManager implements Disposable {
             case SKYBOX:
                 asset = loadSkyboxAsset(meta, assetFile);
                 break;
+            case CUSTOM:
+                asset = loadCustomAsset(meta, assetFile);
+                break;
             default:
                 return null;
         }
@@ -406,6 +409,12 @@ public class AssetManager implements Disposable {
 
     private Asset loadSkyboxAsset(Meta meta, FileHandle assetFile) {
         SkyboxAsset asset = new SkyboxAsset(meta, assetFile);
+        asset.load(gdxAssetManager);
+        return asset;
+    }
+
+    private CustomAsset loadCustomAsset(Meta mea, FileHandle assetFile) {
+        final CustomAsset asset = new CustomAsset(mea, assetFile);
         asset.load(gdxAssetManager);
         return asset;
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetType.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/AssetType.java
@@ -36,7 +36,9 @@ public enum AssetType {
     /** Water file. Contains data for water. */
     WATER("Water"),
     /** Skybox file. Holds reference to skybox textures. **/
-    SKYBOX("Skybox");
+    SKYBOX("Skybox"),
+    /** Custom file. For plugins. **/
+    CUSTOM("Custom");
 
     private final String value;
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
@@ -28,8 +28,8 @@ import java.util.Map;
 public class CustomAsset extends Asset {
 
     /**
-     * @param meta
-     * @param assetFile
+     * @param meta The meta file.
+     * @param assetFile The asset file.
      */
     public CustomAsset(Meta meta, FileHandle assetFile) {
         super(meta, assetFile);

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
@@ -22,6 +22,9 @@ import com.mbrlabs.mundus.commons.assets.meta.Meta;
 
 import java.util.Map;
 
+/**
+ * Custom asset for plugins.
+ */
 public class CustomAsset extends Asset {
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.assets;
+
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.files.FileHandle;
+import com.mbrlabs.mundus.commons.assets.meta.Meta;
+
+import java.util.Map;
+
+public class CustomAsset extends Asset {
+
+    /**
+     * @param meta
+     * @param assetFile
+     */
+    public CustomAsset(Meta meta, FileHandle assetFile) {
+        super(meta, assetFile);
+    }
+
+    @Override
+    public void load() {
+
+    }
+
+    @Override
+    public void load(AssetManager assetManager) {
+
+    }
+
+    @Override
+    public void resolveDependencies(Map<String, Asset> assets) {
+
+    }
+
+    @Override
+    public void applyDependencies() {
+
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    @Override
+    public boolean usesAsset(Asset assetToCheck) {
+        return false;
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/CustomAsset.java
@@ -18,6 +18,7 @@ package com.mbrlabs.mundus.commons.assets;
 
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.mbrlabs.mundus.commons.assets.meta.Meta;
 
 import java.util.Map;
@@ -63,5 +64,9 @@ public class CustomAsset extends Asset {
     @Override
     public boolean usesAsset(Asset assetToCheck) {
         return false;
+    }
+
+    public ObjectMap<String, String> getProperties() {
+        return meta.getCustom().getProperties();
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/Meta.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/Meta.java
@@ -38,6 +38,7 @@ public class Meta {
     public static final String JSON_WATER = "wat";
     public static final String JSON_MODEL = "mdl";
     public static final String JSON_SKY_BOX = "sky";
+    public static final String JSON_CUSTOM = "cus";
 
     private int version;
     private long lastModified;
@@ -46,6 +47,7 @@ public class Meta {
 
     private MetaModel model;
     private MetaTerrain terrain;
+    private MetaCustom custom;
 
     private final FileHandle file;
 
@@ -105,6 +107,14 @@ public class Meta {
         this.terrain = terrain;
     }
 
+    public MetaCustom getCustom() {
+        return custom;
+    }
+
+    public void setCustom(MetaCustom custom) {
+        this.custom = custom;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -131,6 +141,7 @@ public class Meta {
                 ", type=" + type +
                 ", model=" + model +
                 ", terrain=" + terrain +
+                ", custom=" + custom +
                 ", file=" + file +
                 '}';
     }

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaCustom.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaCustom.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mbrlabs.mundus.commons.assets.meta;
+
+import com.badlogic.gdx.utils.ObjectMap;
+
+public class MetaCustom {
+
+    public static final String JSON_PROPERTIES = "properties";
+
+    private final ObjectMap<String, String> properties = new ObjectMap<>();
+
+    public ObjectMap<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "MetaCustom{" +
+                "properties=" + properties +
+                '}';
+    }
+}

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -42,6 +42,8 @@ public class MetaLoader {
             parseTerrain(meta, json.get(Meta.JSON_TERRAIN));
         } else if(meta.getType() == AssetType.MODEL) {
             parseModel(meta, json.get(Meta.JSON_MODEL));
+        } else if (meta.getType() == AssetType.CUSTOM) {
+            parseCustom(meta, json.get(Meta.JSON_CUSTOM));
         }
 
         return meta;
@@ -95,6 +97,22 @@ public class MetaLoader {
         }
 
         meta.setModel(model);
+    }
+
+    private void parseCustom(Meta meta, JsonValue jsonCustom) {
+        if (jsonCustom == null) return;
+
+        final MetaCustom custom = new MetaCustom();
+
+        final JsonValue properties = jsonCustom.get(MetaCustom.JSON_PROPERTIES);
+        for (int i = 0; i < properties.size; ++i) {
+            final JsonValue property = properties.get(i);
+            final String id = property.name;
+            final String value = properties.getString(id);
+            custom.getProperties().get(id, value);
+        }
+
+        meta.setCustom(custom);
     }
 
     /**

--- a/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/assets/meta/MetaLoader.java
@@ -109,7 +109,7 @@ public class MetaLoader {
             final JsonValue property = properties.get(i);
             final String id = property.name;
             final String value = properties.getString(id);
-            custom.getProperties().get(id, value);
+            custom.getProperties().put(id, value);
         }
 
         meta.setCustom(custom);

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomComponentDTO.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.dto;
 
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.OrderedMap;
 
 public class CustomComponentDTO {
@@ -23,6 +24,8 @@ public class CustomComponentDTO {
     private String componentType;
 
     private OrderedMap<String, String> properties;
+
+    private Array<String> assetIds;
 
     public String getComponentType() {
         return componentType;
@@ -38,5 +41,13 @@ public class CustomComponentDTO {
 
     public void setProperties(final OrderedMap<String, String> properties) {
         this.properties = properties;
+    }
+
+    public Array<String> getAssetIds() {
+        return assetIds;
+    }
+
+    public void setAssetIds(final Array<String> assetIds) {
+        this.assetIds = assetIds;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomComponentDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/CustomComponentDTO.java
@@ -18,8 +18,11 @@ package com.mbrlabs.mundus.commons.dto;
 
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.OrderedMap;
+import com.mbrlabs.mundus.commons.assets.Asset;
 
-public class CustomComponentDTO {
+import java.util.Map;
+
+public class CustomComponentDTO implements AssetUsageDTO {
 
     private String componentType;
 
@@ -49,5 +52,20 @@ public class CustomComponentDTO {
 
     public void setAssetIds(final Array<String> assetIds) {
         this.assetIds = assetIds;
+    }
+
+    @Override
+    public boolean usesAsset(final Asset assetToCheck, final Map<String, Asset> assetMap) {
+        if (assetIds == null) {
+            return false;
+        }
+
+        for (int i = 0; i < assetIds.size; ++i) {
+            if (assetToCheck.getID().equals(assetIds.get(i))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/dto/GameObjectDTO.java
@@ -154,6 +154,15 @@ public class GameObjectDTO implements AssetUsageDTO {
             return true;
         }
 
+        if (customComponents != null) {
+            for (int i = 0; i < customComponents.size; ++i) {
+                final CustomComponentDTO customComponent = customComponents.get(i);
+                if (customComponent.usesAsset(assetToCheck, assetMap)) {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomComponentConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomComponentConverter.java
@@ -16,7 +16,10 @@
 
 package com.mbrlabs.mundus.commons.mapper;
 
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.OrderedMap;
+import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 
@@ -36,11 +39,19 @@ public interface CustomComponentConverter {
     OrderedMap<String, String> convert(Component component);
 
     /**
+     * @param component The component.
+     *
+     * @return The ID of used assets.
+     */
+    Array<String> getAssetIds(Component component);
+
+    /**
      * Converts map into custom component.
      *
      * @param gameObject The game object.
      * @param componentProperties The properties of custom component.
+     * @param assets The assets of component.
      * @return The custom component.
      */
-    Component convert(GameObject gameObject, OrderedMap<String, String> componentProperties);
+    Component convert(GameObject gameObject, OrderedMap<String, String> componentProperties, ObjectMap<String, Asset> assets);
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomComponentConverter.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/mapper/CustomComponentConverter.java
@@ -43,7 +43,9 @@ public interface CustomComponentConverter {
      *
      * @return The ID of used assets.
      */
-    Array<String> getAssetIds(Component component);
+    default Array<String> getAssetIds(Component component) {
+        return null;
+    }
 
     /**
      * Converts map into custom component.

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -25,7 +25,7 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 public interface Component {
 
     enum Type {
-        MODEL, TERRAIN, LIGHT, PARTICLE_SYSTEM, WATER, CUSTOM_PROPERTIES, PHYSICS
+        MODEL, TERRAIN, LIGHT, PARTICLE_SYSTEM, WATER, CUSTOM_PROPERTIES, PHYSICS, NAVMESH
     }
 
     GameObject getGameObject();

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/AssetUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/AssetUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.commons.utils;
+
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.mbrlabs.mundus.commons.assets.Asset;
+
+import java.util.Map;
+
+/**
+ * Utils for assets.
+ */
+public class AssetUtils {
+
+    public static ObjectMap<String, Asset> getAssetsById(final Array<String> assetIds, final Map<String, Asset> assetMap) {
+        final ObjectMap<String, Asset> retMap = new ObjectMap<>();
+        if (assetIds != null) {
+            for (int i = 0; i < assetIds.size; ++i) {
+                final String assetId = assetIds.get(i);
+                if (assetId != null) {
+                    final Asset asset = assetMap.get(assetId);
+
+                    if (asset != null) {
+                        retMap.put(assetId, asset);
+                    }
+                }
+            }
+        }
+
+        return retMap;
+    }
+}

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/ProjectChangedEvent.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/ProjectChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016. See AUTHORS file.
+ * Copyright (c) 2024. See AUTHORS file.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,26 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.editor.events
+package com.mbrlabs.mundus.editorcommons.events;
 
-import com.mbrlabs.mundus.editor.core.project.ProjectContext
-import com.mbrlabs.mundus.editorcommons.Subscribe
+import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.editorcommons.Subscribe;
 
-/**
- * @author Marcus Brummer
- * @version 24-12-2015
- */
-class ProjectChangedEvent(val projectContext: ProjectContext) {
+public class ProjectChangedEvent {
 
-    interface ProjectChangedListener {
-        @Subscribe
-        fun onProjectChanged(event: ProjectChangedEvent)
+    private final SceneGraph sceneGraph;
+
+    public ProjectChangedEvent(final SceneGraph sceneGraph) {
+        this.sceneGraph = sceneGraph;
     }
 
+    public SceneGraph getSceneGraph() {
+        return sceneGraph;
+    }
+
+    public interface ProjectChangedListener {
+
+        @Subscribe
+        void onProjectChanged(ProjectChangedEvent event);
+    }
 }

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/ProjectChangedEvent.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/ProjectChangedEvent.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.editorcommons.events;
 
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.editorcommons.EventListener;
 import com.mbrlabs.mundus.editorcommons.Subscribe;
 
 public class ProjectChangedEvent {
@@ -31,7 +32,7 @@ public class ProjectChangedEvent {
         return sceneGraph;
     }
 
-    public interface ProjectChangedListener {
+    public interface ProjectChangedListener extends EventListener {
 
         @Subscribe
         void onProjectChanged(ProjectChangedEvent event);

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/SceneChangedEvent.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/SceneChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016. See AUTHORS file.
+ * Copyright (c) 2024. See AUTHORS file.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.editor.events
+package com.mbrlabs.mundus.editorcommons.events;
 
-import com.mbrlabs.mundus.editorcommons.Subscribe
+import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.editorcommons.Subscribe;
 
-/**
- * @author Marcus Brummer
- * @version 21-01-2016
- */
-class SceneChangedEvent {
+public class SceneChangedEvent {
 
-    interface SceneChangedListener {
-        @Subscribe
-        fun onSceneChanged(event: SceneChangedEvent)
+    private final SceneGraph sceneGraph;
+
+    public SceneChangedEvent(final SceneGraph sceneGraph) {
+        this.sceneGraph = sceneGraph;
     }
 
+    public SceneGraph getSceneGraph() {
+        return sceneGraph;
+    }
+
+    public interface SceneChangedListener {
+
+        @Subscribe
+        void onSceneChanged(SceneChangedEvent event);
+    }
 }

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/SceneChangedEvent.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/events/SceneChangedEvent.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.editorcommons.events;
 
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
+import com.mbrlabs.mundus.editorcommons.EventListener;
 import com.mbrlabs.mundus.editorcommons.Subscribe;
 
 public class SceneChangedEvent {
@@ -31,7 +32,7 @@ public class SceneChangedEvent {
         return sceneGraph;
     }
 
-    public interface SceneChangedListener {
+    public interface SceneChangedListener extends EventListener {
 
         @Subscribe
         void onSceneChanged(SceneChangedEvent event);

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/exceptions/AssetAlreadyExistsException.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/exceptions/AssetAlreadyExistsException.java
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.editor.assets
+package com.mbrlabs.mundus.editorcommons.exceptions;
 
-/**
- * @author Marcus Brummer
- * @version 10-10-2016
- */
-class AssetAlreadyExistsException : Exception()
+public class AssetAlreadyExistsException extends Exception {
+}

--- a/editor-commons/src/com/mbrlabs/mundus/editorcommons/types/ToastType.java
+++ b/editor-commons/src/com/mbrlabs/mundus/editorcommons/types/ToastType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editorcommons.types;
+
+/**
+ * Toast type determines background color of toast.
+ */
+public enum ToastType {
+    SUCCESS, INFO, ERROR
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -38,8 +38,6 @@ import com.mbrlabs.mundus.editor.events.FullScreenEvent
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
 import com.mbrlabs.mundus.editor.events.PluginsLoadedEvent
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.input.FreeCamController
 import com.mbrlabs.mundus.editor.input.InputManager
 import com.mbrlabs.mundus.editor.input.ShortcutController
@@ -59,6 +57,8 @@ import com.mbrlabs.mundus.pluginapi.manager.PluginEventManager
 import com.mbrlabs.mundus.pluginapi.RenderExtension
 import com.mbrlabs.mundus.pluginapi.TerrainSceneExtension
 import com.mbrlabs.mundus.editorcommons.events.GameObjectModifiedEvent
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 import com.mbrlabs.mundus.pluginapi.AssetExtension
 import com.mbrlabs.mundus.pluginapi.CustomShaderRenderExtension
 import com.mbrlabs.mundus.pluginapi.DisposeExtension

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -43,6 +43,7 @@ import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.input.FreeCamController
 import com.mbrlabs.mundus.editor.input.InputManager
 import com.mbrlabs.mundus.editor.input.ShortcutController
+import com.mbrlabs.mundus.editor.plugin.AssetManagerImpl
 import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.profiling.MundusGLProfiler
 import com.mbrlabs.mundus.editor.shader.EditorShaderProvider
@@ -54,10 +55,11 @@ import com.mbrlabs.mundus.editor.utils.Compass
 import com.mbrlabs.mundus.editor.utils.GlUtils
 import com.mbrlabs.mundus.editor.utils.UsefulMeshs
 import com.mbrlabs.mundus.pluginapi.EventExtension
-import com.mbrlabs.mundus.pluginapi.PluginEventManager
+import com.mbrlabs.mundus.pluginapi.manager.PluginEventManager
 import com.mbrlabs.mundus.pluginapi.RenderExtension
 import com.mbrlabs.mundus.pluginapi.TerrainSceneExtension
 import com.mbrlabs.mundus.editorcommons.events.GameObjectModifiedEvent
+import com.mbrlabs.mundus.pluginapi.AssetExtension
 import com.mbrlabs.mundus.pluginapi.CustomShaderRenderExtension
 import com.mbrlabs.mundus.pluginapi.DisposeExtension
 import net.mgsx.gltf.scene3d.scene.SceneRenderableSorter
@@ -318,12 +320,24 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
         pluginManager.plugins.forEach { Mundus.postEvent(LogEvent("Plugin loaded: ${it.pluginId}")) }
 
         // Setup event handling in plugins
-        val pluginEventManager = PluginEventManager { listener -> Mundus.registerEventListener(listener) }
+        val pluginEventManager =
+            PluginEventManager { listener ->
+                Mundus.registerEventListener(listener)
+            }
         pluginManager.getExtensions(EventExtension::class.java).forEach {
             try {
                 it.manageEvents(pluginEventManager)
             } catch (ex: Exception) {
                 Mundus.postEvent(LogEvent(LogType.ERROR, "Exception during manage plugin events! $ex"))
+            }
+        }
+
+        // Setup asset manager for plugins
+        pluginManager.getExtensions(AssetExtension::class.java).forEach {
+            try {
+                it.assetManager(AssetManagerImpl())
+            } catch (ex: Exception) {
+                Mundus.postEvent(LogEvent(LogType.ERROR, "Exception during passing asset manager! $ex"))
             }
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/Editor.kt
@@ -42,6 +42,7 @@ import com.mbrlabs.mundus.editor.input.FreeCamController
 import com.mbrlabs.mundus.editor.input.InputManager
 import com.mbrlabs.mundus.editor.input.ShortcutController
 import com.mbrlabs.mundus.editor.plugin.AssetManagerImpl
+import com.mbrlabs.mundus.editor.plugin.ToasterManagerImpl
 import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
 import com.mbrlabs.mundus.editor.profiling.MundusGLProfiler
 import com.mbrlabs.mundus.editor.shader.EditorShaderProvider
@@ -62,6 +63,7 @@ import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 import com.mbrlabs.mundus.pluginapi.AssetExtension
 import com.mbrlabs.mundus.pluginapi.CustomShaderRenderExtension
 import com.mbrlabs.mundus.pluginapi.DisposeExtension
+import com.mbrlabs.mundus.pluginapi.ToasterExtension
 import net.mgsx.gltf.scene3d.scene.SceneRenderableSorter
 import net.mgsx.gltf.scene3d.shaders.PBRDepthShaderProvider
 import org.apache.commons.io.FileUtils
@@ -338,6 +340,15 @@ class Editor : Lwjgl3WindowAdapter(), ApplicationListener,
                 it.assetManager(AssetManagerImpl())
             } catch (ex: Exception) {
                 Mundus.postEvent(LogEvent(LogType.ERROR, "Exception during passing asset manager! $ex"))
+            }
+        }
+
+        // Setup toaster manager for plugins
+        pluginManager.getExtensions(ToasterExtension::class.java).forEach {
+            try {
+                it.toasterManager(ToasterManagerImpl())
+            } catch (ex: Exception) {
+                Mundus.postEvent(LogEvent(LogType.ERROR, "Exception during passing toaster manager! $ex"))
             }
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -28,6 +28,7 @@ import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.AssetManager
 import com.mbrlabs.mundus.commons.assets.AssetType
+import com.mbrlabs.mundus.commons.assets.CustomAsset
 import com.mbrlabs.mundus.commons.assets.MaterialAsset
 import com.mbrlabs.mundus.commons.assets.ModelAsset
 import com.mbrlabs.mundus.commons.assets.PixmapTextureAsset
@@ -517,6 +518,18 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         val importedAssetFile = copyToAssetFolder(material)
 
         val asset = MaterialAsset(meta, importedAssetFile)
+        asset.load()
+
+        addAsset(asset)
+        return asset
+    }
+
+    @Throws(IOException::class, AssetAlreadyExistsException::class)
+    fun createCustomAsset(file: FileHandle): CustomAsset {
+        val meta = createMetaFileFromAsset(file, AssetType.CUSTOM)
+        val importedAssetFile = copyToAssetFolder(file)
+
+        val asset = CustomAsset(meta, importedAssetFile)
         asset.load()
 
         addAsset(asset)

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -38,6 +38,7 @@ import com.mbrlabs.mundus.commons.assets.TexCoordInfo
 import com.mbrlabs.mundus.commons.assets.TextureAsset
 import com.mbrlabs.mundus.commons.assets.WaterAsset
 import com.mbrlabs.mundus.commons.assets.meta.Meta
+import com.mbrlabs.mundus.commons.assets.meta.MetaCustom
 import com.mbrlabs.mundus.commons.assets.meta.MetaTerrain
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO
 import com.mbrlabs.mundus.commons.dto.SceneDTO
@@ -527,6 +528,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     @Throws(IOException::class, AssetAlreadyExistsException::class)
     fun createCustomAsset(file: FileHandle): CustomAsset {
         val meta = createMetaFileFromAsset(file, AssetType.CUSTOM)
+        meta.custom = MetaCustom()
         val importedAssetFile = copyToAssetFolder(file)
 
         val asset = CustomAsset(meta, importedAssetFile)

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -529,6 +529,7 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
     fun createCustomAsset(file: FileHandle): CustomAsset {
         val meta = createMetaFileFromAsset(file, AssetType.CUSTOM)
         meta.custom = MetaCustom()
+        metaSaver.save(meta)
         val importedAssetFile = copyToAssetFolder(file)
 
         val asset = CustomAsset(meta, importedAssetFile)

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -552,6 +552,8 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
             saveWaterAsset(asset)
         } else if (asset is SkyboxAsset) {
             saveSkyboxAsset(asset)
+        } else if (asset is CustomAsset) {
+            saveCustomAsset(asset)
         }
         // TODO other assets ?
     }
@@ -898,6 +900,11 @@ class EditorAssetManager(assetsRoot: FileHandle) : AssetManager(assetsRoot) {
         fileOutputStream.flush()
         fileOutputStream.close()
 
+        // save meta file
+        metaSaver.save(asset.meta)
+    }
+
+    private fun saveCustomAsset(asset: CustomAsset) {
         // save meta file
         metaSaver.save(asset.meta)
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/EditorAssetManager.kt
@@ -54,6 +54,7 @@ import com.mbrlabs.mundus.editor.events.LogType
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editor.utils.ThumbnailGenerator
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import net.mgsx.gltf.exporters.GLTFExporter
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/MetaSaver.kt
@@ -20,6 +20,7 @@ import com.badlogic.gdx.utils.Json
 import com.badlogic.gdx.utils.JsonWriter
 import com.mbrlabs.mundus.commons.assets.AssetType
 import com.mbrlabs.mundus.commons.assets.meta.Meta
+import com.mbrlabs.mundus.commons.assets.meta.MetaCustom
 import com.mbrlabs.mundus.commons.assets.meta.MetaModel
 import com.mbrlabs.mundus.commons.assets.meta.MetaTerrain
 
@@ -38,6 +39,8 @@ class MetaSaver {
             addTerrain(meta, json)
         } else if(meta.type == AssetType.MODEL) {
             addModel(meta, json)
+        } else if (meta.type == AssetType.CUSTOM) {
+            addCustom(meta, json)
         }
         json.writeObjectEnd()
 
@@ -90,6 +93,20 @@ class MetaSaver {
         if (terrain.splatGNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_G_NORMAL, terrain.splatGNormal)
         if (terrain.splatBNormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_B_NORMAL, terrain.splatBNormal)
         if (terrain.splatANormal != null) json.writeValue(MetaTerrain.JSON_SPLAT_A_NORMAL, terrain.splatANormal)
+        json.writeObjectEnd()
+    }
+
+    private fun addCustom(meta: Meta, json: Json) {
+        val custom = meta.custom ?: return
+
+        json.writeObjectStart(Meta.JSON_CUSTOM)
+        if (custom.properties != null) {
+            json.writeObjectStart(MetaCustom.JSON_PROPERTIES)
+            for (property in custom.properties) {
+                json.writeValue(property.key, property.value)
+            }
+            json.writeObjectEnd()
+        }
         json.writeObjectEnd()
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.editor.core.converter;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.OrderedMap;
 import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.dto.CustomComponentDTO;
@@ -30,6 +31,7 @@ import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
+import com.mbrlabs.mundus.commons.utils.AssetUtils;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableTerrainComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableWaterComponent;
@@ -96,7 +98,9 @@ public class GameObjectConverter {
                     final CustomComponentConverter converter = customComponentConverters.get(ii);
 
                     if (componentType == converter.getComponentType()) {
-                        final Component customComponent = converter.convert(go, customComponentDTO.getProperties());
+                        final Array<String> assetIds = customComponentDTO.getAssetIds();
+                        final ObjectMap<String, Asset> assetMap = AssetUtils.getAssetsById(assetIds, assets);
+                        final Component customComponent = converter.convert(go, customComponentDTO.getProperties(), assetMap);
 
                         if (customComponent != null) {
                             go.getComponents().add(customComponent);
@@ -176,6 +180,7 @@ public class GameObjectConverter {
                             final CustomComponentDTO customComponentDTO = new CustomComponentDTO();
                             customComponentDTO.setComponentType(c.getType().name());
                             customComponentDTO.setProperties(customComponentProperties);
+                            customComponentDTO.setAssetIds(converter.getAssetIds(c));
 
                             descriptor.getCustomComponents().add(customComponentDTO);
                         }

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -49,14 +49,14 @@ import com.mbrlabs.mundus.editor.core.registry.Registry;
 import com.mbrlabs.mundus.editor.core.scene.SceneManager;
 import com.mbrlabs.mundus.editor.events.LogEvent;
 import com.mbrlabs.mundus.editor.events.LogType;
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent;
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableComponent;
 import com.mbrlabs.mundus.editor.shader.Shaders;
 import com.mbrlabs.mundus.editor.ui.UI;
 import com.mbrlabs.mundus.editor.utils.Log;
 import com.mbrlabs.mundus.editor.utils.PluginUtils;
 import com.mbrlabs.mundus.editor.utils.SkyboxBuilder;
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent;
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent;
 import org.pf4j.PluginManager;
 
 import java.io.File;
@@ -431,7 +431,7 @@ public class ProjectManager implements Disposable {
         ioManager.saveRegistry(registry);
 
         Gdx.graphics.setTitle(constructWindowTitle());
-        Mundus.INSTANCE.postEvent(new ProjectChangedEvent(context));
+        Mundus.INSTANCE.postEvent(new ProjectChangedEvent(context.currScene.sceneGraph));
         currentProject.currScene.onLoaded();
     }
 
@@ -520,7 +520,7 @@ public class ProjectManager implements Disposable {
             projectContext.currScene = newScene;
 
             Gdx.graphics.setTitle(constructWindowTitle());
-            Mundus.INSTANCE.postEvent(new SceneChangedEvent());
+            Mundus.INSTANCE.postEvent(new SceneChangedEvent(projectContext.currScene.sceneGraph));
             projectContext.currScene.onLoaded();
         } catch (FileNotFoundException e) {
             e.printStackTrace();

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/project/ProjectManager.java
@@ -39,7 +39,6 @@ import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.WaterComponent;
 import com.mbrlabs.mundus.editor.Main;
 import com.mbrlabs.mundus.editor.Mundus;
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException;
 import com.mbrlabs.mundus.editor.assets.EditorAssetManager;
 import com.mbrlabs.mundus.editor.core.EditorScene;
 import com.mbrlabs.mundus.editor.core.converter.SceneConverter;
@@ -57,6 +56,7 @@ import com.mbrlabs.mundus.editor.utils.PluginUtils;
 import com.mbrlabs.mundus.editor.utils.SkyboxBuilder;
 import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent;
 import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent;
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException;
 import org.pf4j.PluginManager;
 
 import java.io.File;

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -21,6 +21,7 @@ import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.CustomAsset
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.events.AssetDeletedEvent
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
@@ -41,5 +42,6 @@ class AssetManagerImpl : AssetManager {
 
     override fun deleteAsset(asset: CustomAsset) {
         projectManager.current().assetManager.deleteAsset(asset)
+        Mundus.postEvent(AssetDeletedEvent())
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -19,14 +19,15 @@ package com.mbrlabs.mundus.editor.plugin
 import com.badlogic.gdx.files.FileHandle
 import com.mbrlabs.mundus.commons.assets.CustomAsset
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.EditorAssetManager
+import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
 class AssetManagerImpl : AssetManager {
 
-    private val assetManager: EditorAssetManager = Mundus.inject()
+    private val projectManager = Mundus.inject<ProjectManager>()
 
     override fun createNewAsset(file: FileHandle): CustomAsset {
+        val assetManager = projectManager.current().assetManager
         return assetManager.createCustomAsset(file)
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.editor.plugin
 
 import com.badlogic.gdx.files.FileHandle
+import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.CustomAsset
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -32,5 +33,9 @@ class AssetManagerImpl : AssetManager {
         val customAsset = assetManager.createCustomAsset(file)
         Mundus.postEvent(AssetImportEvent(customAsset))
         return customAsset
+    }
+
+    override fun markAsModifiedAsset(asset: Asset) {
+        projectManager.current().assetManager.addModifiedAsset(asset)
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -38,4 +38,8 @@ class AssetManagerImpl : AssetManager {
     override fun markAsModifiedAsset(asset: Asset) {
         projectManager.current().assetManager.addModifiedAsset(asset)
     }
+
+    override fun deleteAsset(asset: CustomAsset) {
+        projectManager.current().assetManager.deleteAsset(asset)
+    }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -16,12 +16,17 @@
 
 package com.mbrlabs.mundus.editor.plugin
 
-import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
+import com.mbrlabs.mundus.commons.assets.CustomAsset
+import com.mbrlabs.mundus.editor.Mundus
+import com.mbrlabs.mundus.editor.assets.EditorAssetManager
 import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
 class AssetManagerImpl : AssetManager {
-    override fun createNewAsset() {
-        // TODO implement later
-        Gdx.app.log("", "Create new asset")
+
+    private val assetManager: EditorAssetManager = Mundus.inject()
+
+    override fun createNewAsset(file: FileHandle): CustomAsset {
+        return assetManager.createCustomAsset(file)
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -20,6 +20,7 @@ import com.badlogic.gdx.files.FileHandle
 import com.mbrlabs.mundus.commons.assets.CustomAsset
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
+import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
 class AssetManagerImpl : AssetManager {
@@ -28,6 +29,8 @@ class AssetManagerImpl : AssetManager {
 
     override fun createNewAsset(file: FileHandle): CustomAsset {
         val assetManager = projectManager.current().assetManager
-        return assetManager.createCustomAsset(file)
+        val customAsset = assetManager.createCustomAsset(file)
+        Mundus.postEvent(AssetImportEvent(customAsset))
+        return customAsset
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -23,12 +23,14 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetDeletedEvent
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
 class AssetManagerImpl : AssetManager {
 
     private val projectManager = Mundus.inject<ProjectManager>()
 
+    @Throws(AssetAlreadyExistsException::class)
     override fun createNewAsset(file: FileHandle): CustomAsset {
         val assetManager = projectManager.current().assetManager
         val customAsset = assetManager.createCustomAsset(file)

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/AssetManagerImpl.kt
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.pluginapi;
+package com.mbrlabs.mundus.editor.plugin
 
-import com.mbrlabs.mundus.pluginapi.manager.PluginEventManager;
-import org.pf4j.ExtensionPoint;
+import com.badlogic.gdx.Gdx
+import com.mbrlabs.mundus.pluginapi.manager.AssetManager
 
-public interface EventExtension extends ExtensionPoint {
-
-    /**
-     * Here can register events via plugin event manager.
-     *
-     * @param pluginEventManager The plugin event manager.
-     */
-    void manageEvents(PluginEventManager pluginEventManager);
+class AssetManagerImpl : AssetManager {
+    override fun createNewAsset() {
+        // TODO implement later
+        Gdx.app.log("", "Create new asset")
+    }
 }

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/LabelCellImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/LabelCellImpl.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.plugin
+
+import com.badlogic.gdx.scenes.scene2d.ui.Cell
+import com.mbrlabs.mundus.pluginapi.ui.Label
+import com.mbrlabs.mundus.pluginapi.ui.LabelCell
+
+class LabelCellImpl(private val labelCell: Cell<LabelImpl>) : CellImpl(labelCell), LabelCell {
+    override fun getLabel(): Label = labelCell.actor
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/LabelImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/LabelImpl.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.plugin
+
+import com.kotcrab.vis.ui.widget.VisLabel
+import com.mbrlabs.mundus.pluginapi.ui.Label
+
+class LabelImpl(text: String) : VisLabel(text), Label {
+    override fun setText(text: String) {
+        setText(text as CharSequence)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
@@ -43,13 +43,14 @@ import com.mbrlabs.mundus.pluginapi.ui.RootWidget
 import com.mbrlabs.mundus.pluginapi.ui.IntSpinnerListener
 import com.mbrlabs.mundus.pluginapi.ui.SpinnerListener
 import com.mbrlabs.mundus.pluginapi.ui.Cell
+import com.mbrlabs.mundus.pluginapi.ui.LabelCell
 import com.mbrlabs.mundus.pluginapi.ui.RootWidgetCell
 import com.mbrlabs.mundus.pluginapi.ui.SelectBoxListener
 import com.mbrlabs.mundus.pluginapi.ui.TextFieldChangeListener
 
 class RootWidgetImpl : VisTable(), RootWidget {
 
-    override fun addLabel(text: String): Cell {
+    override fun addLabel(text: String): LabelCell {
         val label = LabelImpl(text)
         val cell = add(label)
         return LabelCellImpl(cell)

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
@@ -11,6 +11,7 @@ import com.kotcrab.vis.ui.widget.VisRadioButton
 import com.kotcrab.vis.ui.widget.VisSelectBox
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
+import com.kotcrab.vis.ui.widget.VisTextField
 import com.kotcrab.vis.ui.widget.spinner.IntSpinnerModel
 import com.kotcrab.vis.ui.widget.spinner.SimpleFloatSpinnerModel
 import com.kotcrab.vis.ui.widget.spinner.Spinner
@@ -28,12 +29,25 @@ import com.mbrlabs.mundus.pluginapi.ui.SpinnerListener
 import com.mbrlabs.mundus.pluginapi.ui.Cell
 import com.mbrlabs.mundus.pluginapi.ui.RootWidgetCell
 import com.mbrlabs.mundus.pluginapi.ui.SelectBoxListener
+import com.mbrlabs.mundus.pluginapi.ui.TextFieldChangeListener
 
 class RootWidgetImpl : VisTable(), RootWidget {
 
     override fun addLabel(text: String): Cell {
         val label = VisLabel(text)
         val cell = add(label)
+        return CellImpl(cell)
+    }
+
+    override fun addTextField(listener: TextFieldChangeListener): Cell {
+        val textField = VisTextField()
+        textField.addListener(object : ChangeListener() {
+            override fun changed(event: ChangeEvent, actor: Actor) {
+                listener.changed(textField.text)
+            }
+        })
+
+        val cell = add(textField)
         return CellImpl(cell)
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/RootWidgetImpl.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mbrlabs.mundus.editor.plugin
 
 import com.badlogic.gdx.scenes.scene2d.Actor
@@ -34,9 +50,9 @@ import com.mbrlabs.mundus.pluginapi.ui.TextFieldChangeListener
 class RootWidgetImpl : VisTable(), RootWidget {
 
     override fun addLabel(text: String): Cell {
-        val label = VisLabel(text)
+        val label = LabelImpl(text)
         val cell = add(label)
-        return CellImpl(cell)
+        return LabelCellImpl(cell)
     }
 
     override fun addTextField(listener: TextFieldChangeListener): Cell {

--- a/editor/src/main/com/mbrlabs/mundus/editor/plugin/ToasterManagerImpl.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/plugin/ToasterManagerImpl.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.editor.plugin
+
+import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editorcommons.types.ToastType
+import com.mbrlabs.mundus.pluginapi.manager.ToasterManager
+
+class ToasterManagerImpl : ToasterManager {
+
+    override fun info(text: String) {
+        UI.toaster.info(text)
+    }
+
+    override fun error(text: String) {
+        UI.toaster.error(text)
+    }
+
+    override fun success(text: String) {
+        UI.toaster.success(text)
+    }
+
+    override fun sticky(type: ToastType, text: String) {
+        UI.toaster.sticky(type, text)
+    }
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/GizmoManager.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/gizmos/GizmoManager.kt
@@ -9,9 +9,9 @@ import com.mbrlabs.mundus.commons.scene3d.components.LightComponent
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.ComponentRemovedEvent
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * Responsible for rendering Gizmos in the scene and listens for when new components are added.

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -60,9 +60,14 @@ class AddComponentDialog : BaseDialog("Add Component") {
         })
         pluginManager.getExtensions(ComponentExtension::class.java).forEach {
             try {
-                addableTypes.add(object : DropdownComponent(it.componentName) {
-                    override fun createComponent(gameObject: GameObject): Component? = it.createComponent(gameObject)
-                })
+                val supportedComponentTypes = it.getSupportedComponentTypes(getSelectedGameObject())
+
+                if (supportedComponentTypes == null || containsSupportedComponentType(supportedComponentTypes)) {
+                    addableTypes.add(object : DropdownComponent(it.componentName) {
+                        override fun createComponent(gameObject: GameObject): Component? =
+                            it.createComponent(gameObject)
+                    })
+                }
             } catch (ex: Exception) {
                 Mundus.postEvent(LogEvent(LogType.ERROR, "Exception during create component! $ex"))
             }
@@ -88,11 +93,27 @@ class AddComponentDialog : BaseDialog("Add Component") {
         add(root)
     }
 
+    private fun getSelectedGameObject(): GameObject {
+        return UI.outline.getSelectedGameObject()!!
+    }
+
+    private fun containsSupportedComponentType(supportedComponentTypes: Array<Component.Type>): Boolean {
+        val gameObject = getSelectedGameObject()
+
+        for (supportedComponentType in supportedComponentTypes) {
+            if (gameObject.findComponentByType<Component>(supportedComponentType) != null) {
+                return true
+            }
+        }
+
+        return false
+    }
+
     private fun setupListeners() {
         addBtn.addListener(object : ClickListener () {
             override fun clicked(event: InputEvent?, x: Float, y: Float) {
                 // Add component to current game object
-                val go = UI.outline.getSelectedGameObject()!!
+                val go = getSelectedGameObject()
 
                 val component = selectBox.selected.createComponent(go)
                 if (component != null) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddComponentDialog.kt
@@ -60,7 +60,7 @@ class AddComponentDialog : BaseDialog("Add Component") {
         })
         pluginManager.getExtensions(ComponentExtension::class.java).forEach {
             try {
-                val supportedComponentTypes = it.getSupportedComponentTypes(getSelectedGameObject())
+                val supportedComponentTypes = it.supportedComponentTypes
 
                 if (supportedComponentTypes == null || containsSupportedComponentType(supportedComponentTypes)) {
                     addableTypes.add(object : DropdownComponent(it.componentName) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainDialog.kt
@@ -31,7 +31,6 @@ import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent
 import com.mbrlabs.mundus.commons.terrain.SplatMapResolution
 import com.mbrlabs.mundus.commons.terrain.Terrain
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.io.IOManager
 import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -44,6 +43,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editor.utils.createTerrainGO
 import com.mbrlabs.mundus.editorcommons.events.TerrainAddedEvent
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddWaterDialog.kt
@@ -12,7 +12,6 @@ import com.mbrlabs.mundus.commons.assets.WaterAsset
 import com.mbrlabs.mundus.commons.scene3d.GameObject
 import com.mbrlabs.mundus.commons.water.Water
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.io.IOManager
 import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -24,6 +23,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.IntegerFieldWithLabel
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editor.utils.createWaterGO
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 
 class AddWaterDialog : BaseDialog("Add Water") {
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AmbientLightDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AmbientLightDialog.kt
@@ -23,9 +23,9 @@ import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.color.ColorPickerAdapter
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.widgets.ColorPickerField
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/DirectionalLightsDialog.kt
@@ -17,12 +17,12 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.ColorPickerField
 import com.mbrlabs.mundus.editor.ui.widgets.ImprovedSlider
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * @author JamesTKhan

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/ExportDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/ExportDialog.kt
@@ -29,6 +29,7 @@ import com.mbrlabs.mundus.editor.exporter.Exporter
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editor.utils.Toaster
+import com.mbrlabs.mundus.editorcommons.types.ToastType
 import org.pf4j.PluginManager
 
 /**
@@ -94,7 +95,7 @@ class ExportDialog : VisDialog("Exporting") {
 
             override fun failed(message: String?, exception: Exception?) {
                 Log.exception("Exporter", exception)
-                UI.toaster.sticky(Toaster.ToastType.ERROR, "Export failed: " + exception.toString())
+                UI.toaster.sticky(ToastType.ERROR, "Export failed: " + exception.toString())
                 error = true
                 resetValues()
                 close()

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/FogDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/FogDialog.kt
@@ -27,9 +27,9 @@ import com.kotcrab.vis.ui.widget.VisTextField
 import com.kotcrab.vis.ui.widget.color.ColorPickerAdapter
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.widgets.ColorPickerField
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 import net.mgsx.gltf.scene3d.attributes.FogAttribute
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/ShadowSettingsDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/ShadowSettingsDialog.kt
@@ -15,9 +15,9 @@ import com.mbrlabs.mundus.commons.shadows.ShadowResolution
 import com.mbrlabs.mundus.commons.utils.LightUtils
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * @author JamesTKhan

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
@@ -40,11 +40,11 @@ import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.shader.Shaders
 import com.mbrlabs.mundus.editor.ui.widgets.ImageChooserField
 import com.mbrlabs.mundus.editor.utils.createDefaultSkybox
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/SkyboxDialog.kt
@@ -36,7 +36,6 @@ import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.SkyboxAsset
 import com.mbrlabs.mundus.commons.skybox.Skybox
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
@@ -45,6 +44,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.ImageChooserField
 import com.mbrlabs.mundus.editor.utils.createDefaultSkybox
 import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/assets/AssetPickerDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/assets/AssetPickerDialog.kt
@@ -28,10 +28,10 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.assets.AssetFilter
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.BaseDialog
 import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusListView
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 
 /**
  * A filterable list of materials.

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportModelDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportModelDialog.kt
@@ -48,7 +48,6 @@ import com.mbrlabs.mundus.commons.utils.ModelUtils
 import com.mbrlabs.mundus.commons.utils.MundusShaderParser
 import com.mbrlabs.mundus.commons.utils.ShaderUtils
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.assets.FileHandleWithDependencies
 import com.mbrlabs.mundus.editor.assets.MetaSaver
 import com.mbrlabs.mundus.editor.assets.ModelImporter
@@ -67,6 +66,7 @@ import com.mbrlabs.mundus.editor.utils.isG3DB
 import com.mbrlabs.mundus.editor.utils.isGLB
 import com.mbrlabs.mundus.editor.utils.isGLTF
 import com.mbrlabs.mundus.editor.utils.isWavefont
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import net.mgsx.gltf.loaders.glb.GLBLoader
 import net.mgsx.gltf.loaders.gltf.GLTFLoader
 import net.mgsx.gltf.scene3d.attributes.PBRCubemapAttribute

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportTextureDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/importer/ImportTextureDialog.kt
@@ -27,7 +27,6 @@ import com.kotcrab.vis.ui.util.dialog.Dialogs
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.FilesDroppedEvent
@@ -37,6 +36,7 @@ import com.mbrlabs.mundus.editor.ui.widgets.ImageChooserField
 import com.mbrlabs.mundus.editor.utils.ImageUtils
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editor.utils.isImage
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import java.io.File
 import java.io.IOException
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/CameraSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/CameraSettingsTable.kt
@@ -32,9 +32,9 @@ import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.core.scene.SceneManager
 import com.mbrlabs.mundus.editor.events.LogEvent
 import com.mbrlabs.mundus.editor.events.LogType
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 import org.pf4j.PluginManager
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/ExportSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/ExportSettingsTable.kt
@@ -26,9 +26,9 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.io.IOManager
 import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.FileChooserField
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/settings/PerformanceSettingsTable.kt
@@ -9,10 +9,10 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.plugin.PluginManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.core.scene.SceneManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
-import com.mbrlabs.mundus.editor.events.SceneChangedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 import org.pf4j.PluginManager
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dock/assets/AssetsDock.kt
@@ -46,6 +46,7 @@ import com.mbrlabs.mundus.editor.events.*
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 import com.mbrlabs.mundus.editor.utils.ObjExporter
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 import java.awt.Desktop
 import java.lang.RuntimeException
 

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/Inspector.kt
@@ -24,10 +24,10 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.events.AssetSelectedEvent
 import com.mbrlabs.mundus.editor.events.ComponentAddedEvent
 import com.mbrlabs.mundus.editor.events.GameObjectSelectedEvent
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.ui.widgets.AutoFocusScrollPane
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editorcommons.events.GameObjectModifiedEvent
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/inspector/components/terrain/TerrainPaintTab.kt
@@ -28,7 +28,6 @@ import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.TextureAsset
 import com.mbrlabs.mundus.commons.terrain.SplatTexture
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.assets.AssetTextureFilter
 import com.mbrlabs.mundus.editor.assets.MetaSaver
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
@@ -38,6 +37,7 @@ import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.assets.AssetPickerDialog
 import com.mbrlabs.mundus.editor.ui.widgets.TextureGrid
 import com.mbrlabs.mundus.editor.utils.Log
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import java.io.IOException
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/menu/SceneMenu.kt
@@ -31,10 +31,10 @@ import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.io.IOManager
 import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.events.SceneAddedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Log
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 
 /**
  * @author Marcus Brummer

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/outline/Outline.kt
@@ -47,6 +47,8 @@ import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.utils.Colors
 import com.mbrlabs.mundus.editor.utils.Log
 import com.mbrlabs.mundus.editorcommons.events.GameObjectModifiedEvent
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent
 
 /**
  * Outline shows overview about all game objects in the scene

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialSelectWidget.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/MaterialSelectWidget.kt
@@ -11,7 +11,6 @@ import com.kotcrab.vis.ui.widget.VisTextButton
 import com.mbrlabs.mundus.commons.assets.Asset
 import com.mbrlabs.mundus.commons.assets.MaterialAsset
 import com.mbrlabs.mundus.editor.Mundus
-import com.mbrlabs.mundus.editor.assets.AssetAlreadyExistsException
 import com.mbrlabs.mundus.editor.assets.AssetMaterialFilter
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetSelectedEvent
@@ -19,6 +18,7 @@ import com.mbrlabs.mundus.editor.events.MaterialDuplicatedEvent
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.assets.AssetPickerDialog
 import com.mbrlabs.mundus.editor.utils.Colors
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import java.io.FileNotFoundException
 
 /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/PersistingFileChooser.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/widgets/PersistingFileChooser.kt
@@ -3,8 +3,8 @@ package com.mbrlabs.mundus.editor.ui.widgets
 import com.kotcrab.vis.ui.widget.file.FileChooser
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.events.ProjectChangedEvent
 import com.mbrlabs.mundus.editor.preferences.MundusPreferencesManager
+import com.mbrlabs.mundus.editorcommons.events.ProjectChangedEvent
 
 /**
  * Extends FileChooser to add behavior that sets the current chooser directory to the

--- a/editor/src/main/com/mbrlabs/mundus/editor/utils/Toaster.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/utils/Toaster.kt
@@ -21,6 +21,7 @@ import com.kotcrab.vis.ui.util.ToastManager
 import com.kotcrab.vis.ui.widget.VisLabel
 import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.toast.Toast
+import com.mbrlabs.mundus.editorcommons.types.ToastType
 import java.util.*
 
 /**
@@ -30,11 +31,6 @@ import java.util.*
  * @version 07-06-2016
  */
 class Toaster(stage: Stage) {
-
-    /** Toast type determines background color of toast.  */
-    enum class ToastType {
-        SUCCESS, INFO, ERROR
-    }
 
     private val toastManager: ToastManager = ToastManager(stage)
 

--- a/editor/src/test/java/com/mbrlabs/mundus/editor/events/EventBusTest.java
+++ b/editor/src/test/java/com/mbrlabs/mundus/editor/events/EventBusTest.java
@@ -1,6 +1,7 @@
 package com.mbrlabs.mundus.editor.events;
 
 import com.mbrlabs.mundus.editorcommons.Subscribe;
+import com.mbrlabs.mundus.editorcommons.events.SceneChangedEvent;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class EventBusTest {
         int sceneAddedCount = 5;
 
         for (int i = 0; i < sceneChangedCount; i++) {
-            eventBus.post(new SceneChangedEvent());
+            eventBus.post(new SceneChangedEvent(null));
         }
 
         for (int i = 0; i < sceneAddedCount; i++) {
@@ -60,11 +61,11 @@ public class EventBusTest {
 
         // register and post, should receive 1 event
         eventBus.register(subscriber);
-        eventBus.post(new SceneChangedEvent());
+        eventBus.post(new SceneChangedEvent(null));
 
         // unregister and post, should not receive any events
         eventBus.unregister(subscriber);
-        eventBus.post(new SceneChangedEvent());
+        eventBus.post(new SceneChangedEvent(null));
 
         // should still be 1
         Assert.assertEquals(sceneChangedEventsReceived[0], 1);

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
@@ -16,6 +16,9 @@
 
 package com.mbrlabs.mundus.runtime.converter;
 
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.assets.AssetManager;
 import com.mbrlabs.mundus.commons.dto.CustomComponentDTO;
 import com.mbrlabs.mundus.commons.dto.GameObjectDTO;
@@ -25,6 +28,7 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.runtime.Shaders;
+import com.mbrlabs.mundus.commons.utils.AssetUtils;
 
 /**
  * Converter for game object.
@@ -82,7 +86,9 @@ public class GameObjectConverter {
                     final CustomComponentConverter converter = customComponentConverters[ii];
 
                     if (customComponentDTO.getComponentType().equals(converter.getComponentType().name())) {
-                        final Component component = converter.convert(go, customComponentDTO.getProperties());
+                        final Array<String> assetIds = customComponentDTO.getAssetIds();
+                        final ObjectMap<String, Asset> assetMap = AssetUtils.getAssetsById(assetIds, assetManager.getAssetMap());
+                        final Component component = converter.convert(go, customComponentDTO.getProperties(), assetMap);
 
                         if (component != null) {
                             go.getComponents().add(component);

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/AssetExtension.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/AssetExtension.java
@@ -16,15 +16,10 @@
 
 package com.mbrlabs.mundus.pluginapi;
 
-import com.mbrlabs.mundus.pluginapi.manager.PluginEventManager;
+import com.mbrlabs.mundus.pluginapi.manager.AssetManager;
 import org.pf4j.ExtensionPoint;
 
-public interface EventExtension extends ExtensionPoint {
+public interface AssetExtension extends ExtensionPoint {
 
-    /**
-     * Here can register events via plugin event manager.
-     *
-     * @param pluginEventManager The plugin event manager.
-     */
-    void manageEvents(PluginEventManager pluginEventManager);
+    void assetManager(AssetManager assetManager);
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ComponentExtension.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ComponentExtension.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.pluginapi;
 
+import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.mapper.CustomComponentConverter;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
@@ -23,6 +24,18 @@ import com.mbrlabs.mundus.pluginapi.ui.RootWidget;
 import org.pf4j.ExtensionPoint;
 
 public interface ComponentExtension extends ExtensionPoint {
+
+    /**
+     * Returns with the supported component types.
+     * If the game object contains a supported component type then the component can be added via plugin.
+     * The default value is null, in this case the Editor doesn't check component types.
+     *
+     * @param gameObject The game object.
+     * @return Null or array of supported component types.
+     */
+    default Array<Component.Type> getSupportedComponentTypes(GameObject gameObject) {
+        return null;
+    }
 
     /**
      * @return The component type what the plugin use.

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ComponentExtension.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ComponentExtension.java
@@ -30,10 +30,9 @@ public interface ComponentExtension extends ExtensionPoint {
      * If the game object contains a supported component type then the component can be added via plugin.
      * The default value is null, in this case the Editor doesn't check component types.
      *
-     * @param gameObject The game object.
      * @return Null or array of supported component types.
      */
-    default Array<Component.Type> getSupportedComponentTypes(GameObject gameObject) {
+    default Array<Component.Type> getSupportedComponentTypes() {
         return null;
     }
 

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ToasterExtension.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ToasterExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.pluginapi;
+
+import com.mbrlabs.mundus.pluginapi.manager.ToasterManager;
+import org.pf4j.ExtensionPoint;
+
+public interface ToasterExtension extends ExtensionPoint {
+
+    void toasterManager(ToasterManager toasterManager);
+}

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.pluginapi.manager;
 import com.badlogic.gdx.files.FileHandle;
 import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.assets.CustomAsset;
+import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException;
 
 public interface AssetManager {
 
@@ -26,8 +27,10 @@ public interface AssetManager {
      * Creates new asset.
      *
      * @param file The file for asset.
+     *
+     * @throws AssetAlreadyExistsException If asset already exists.
      */
-    CustomAsset createNewAsset(FileHandle file);
+    CustomAsset createNewAsset(FileHandle file) throws AssetAlreadyExistsException;
 
     /**
      * Marks asset as modified asset.

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
@@ -17,6 +17,7 @@
 package com.mbrlabs.mundus.pluginapi.manager;
 
 import com.badlogic.gdx.files.FileHandle;
+import com.mbrlabs.mundus.commons.assets.Asset;
 import com.mbrlabs.mundus.commons.assets.CustomAsset;
 
 public interface AssetManager {
@@ -27,4 +28,11 @@ public interface AssetManager {
      * @param file The file for asset.
      */
     CustomAsset createNewAsset(FileHandle file);
+
+    /**
+     * Marks asset as modified asset.
+     *
+     * @param asset The modified asset.
+     */
+    void markAsModifiedAsset(Asset asset);
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.pluginapi;
+package com.mbrlabs.mundus.pluginapi.manager;
 
-import com.mbrlabs.mundus.pluginapi.manager.PluginEventManager;
-import org.pf4j.ExtensionPoint;
-
-public interface EventExtension extends ExtensionPoint {
+public interface AssetManager {
 
     /**
-     * Here can register events via plugin event manager.
-     *
-     * @param pluginEventManager The plugin event manager.
+     * Creates new asset.
      */
-    void manageEvents(PluginEventManager pluginEventManager);
+    void createNewAsset();
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
@@ -35,4 +35,11 @@ public interface AssetManager {
      * @param asset The modified asset.
      */
     void markAsModifiedAsset(Asset asset);
+
+    /**
+     * Deletes custom asset.
+     *
+     * @param asset The asset.
+     */
+    void deleteAsset(CustomAsset asset);
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/AssetManager.java
@@ -16,10 +16,15 @@
 
 package com.mbrlabs.mundus.pluginapi.manager;
 
+import com.badlogic.gdx.files.FileHandle;
+import com.mbrlabs.mundus.commons.assets.CustomAsset;
+
 public interface AssetManager {
 
     /**
      * Creates new asset.
+     *
+     * @param file The file for asset.
      */
-    void createNewAsset();
+    CustomAsset createNewAsset(FileHandle file);
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/PluginEventManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/PluginEventManager.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.mbrlabs.mundus.pluginapi;
+package com.mbrlabs.mundus.pluginapi.manager;
 
 import com.mbrlabs.mundus.editorcommons.EventListener;
 
 public interface PluginEventManager {
 
     /**
-     * Registerrs event listeners in Editor.
+     * Registers event listeners in Editor.
      *
      * @param listener The event listener.
      */

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/ToasterManager.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/manager/ToasterManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.pluginapi.manager;
+
+import com.mbrlabs.mundus.editorcommons.types.ToastType;
+
+public interface ToasterManager {
+
+    /**
+     * Shows toaster message as info status for some seconds.
+     *
+     * @param text The text.
+     */
+    void info(String text);
+
+    /**
+     * Shows toaster message as error status for some seconds.
+     *
+     * @param text The text.
+     */
+    void error(String text);
+
+    /**
+     * Shows toaster message as success status for some seconds.
+     *
+     * @param text The text.
+     */
+    void success(String text);
+
+    /**
+     * Shows toaster message until the user close it.
+     *
+     * @param type The type of text.
+     * @param text The text.
+     */
+    void sticky(ToastType type, String text);
+
+}

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/Label.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/Label.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.pluginapi.ui;
+
+/**
+ * Label widget.
+ */
+public interface Label {
+
+    /**
+     * Sets text on widget.
+     *
+     * @param text The new text.
+     */
+    void setText(String text);
+}

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/LabelCell.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/LabelCell.java
@@ -16,7 +16,7 @@
 
 package com.mbrlabs.mundus.pluginapi.ui;
 
-public interface LabelCell {
+public interface LabelCell extends Cell {
 
     Label getLabel();
 }

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/LabelCell.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/LabelCell.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.pluginapi.ui;
+
+public interface LabelCell {
+
+    Label getLabel();
+}

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/RootWidget.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/RootWidget.java
@@ -31,6 +31,13 @@ public interface RootWidget {
     Cell addLabel(String text);
 
     /**
+     * Adds text field.
+     * @param listener The listener for text field.
+     * @return The created text field.
+     */
+    Cell addTextField(TextFieldChangeListener listener);
+
+    /**
      * Adds text button.
      *
      * @param text The ext of button.

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/RootWidget.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/RootWidget.java
@@ -28,7 +28,7 @@ public interface RootWidget {
      * @param text The text of label.
      * @return The created widget.
      */
-    Cell addLabel(String text);
+    LabelCell addLabel(String text);
 
     /**
      * Adds text field.

--- a/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/TextFieldChangeListener.java
+++ b/plugin-api/src/com/mbrlabs/mundus/pluginapi/ui/TextFieldChangeListener.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024. See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mbrlabs.mundus.pluginapi.ui;
+
+
+public interface TextFieldChangeListener {
+
+    void changed(String newValue);
+}


### PR DESCRIPTION
This PR expands functionality of plugin system [^1] [^2]. The purpose is that plugin can add new custom asset what runtime can load (via plugin's runtime module).

**Changes:** 
Add new component type: `NAVMESH`

Add custom asset type.

**New extension interfaces:**
- **AssetExtension**:
    - `void assetManager(AssetManager)`: Can handle custom assets via AssetManager. 
- **ToasterExtension**:
    - `void toasterManager(ToasterManager)`: Can handle toaster messages via ToasterManager.

**Modified extension interfaces:**
- **ComponentExtension**:
  - `default Array<Component.Type> getSupportedComponentTypes() { return null }`: Can handle where can create new component. For example: Create NavMesh component only on game object what contains terrain component.

**Plugin's RootWidget additions:**
- `addTextField(TextFieldChangeListener)`: Adds textfield with change listener.

**New subscribable editor events:**
- **ProjectChangedEvent**: If the project changed.
- **SceneChangedEvent**: If the scene changed

Tested it with HTML and it works well.

You can try it with Mundus Example Project with Recast NavMesh plugin:
https://github.com/Dgzt/MundusRuntimeExample/tree/recast-navmesh-plugin
(use mouse buttons to select start and end positions, G for debug renderer)

[^1]: https://github.com/JamesTKhan/Mundus/pull/268
[^2]: https://github.com/JamesTKhan/Mundus/pull/289