### PR TITLE
splatNormal initialization fix

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
+++ b/commons/src/main/com/mbrlabs/mundus/commons/shaders/pbr/material.glsl
@@ -340,7 +340,7 @@ vec3 getNormal()
     vec3 n = getColor(u_normalTexture, colorUv).rgb;
 
     #ifdef splatFlag
-    vec3 splatNormal;
+        vec3 splatNormal = vec3(0.0);
     #ifdef splatRNormalFlag
         splatNormal += getColor(u_texture_r_normal, colorUv).rgb * splat.r;
     #endif


### PR DESCRIPTION
Initialization fix for splatNormal variable.

Before fix:
![before](https://github.com/user-attachments/assets/5c0269ab-4488-4f4d-bbc0-ff9f80c74c3a)

After fix:
![after](https://github.com/user-attachments/assets/08193937-b050-4ae2-a6de-271cd6f4672c)
