### PR TITLE
Fix NPE if material has not name field. Fix ClassCastException at AlpaTest float attribute

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -26,6 +26,8 @@
 - Add editor plugin support
 - Removed helper lines (moved into plugin, see https://github.com/Dgzt/mundus-helper-lines-plugin)
 - Update gdx-gltf version to 2.2.1
+- Fix gltf import when material has not name field
+- Fix gltf import when has alpha material attribute
 
 [0.5.1] ~ 08/08/2023
 - Added FPS launcher argument, always call setForegroundFPS

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/ModelImporter.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/ModelImporter.kt
@@ -21,6 +21,7 @@ import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.g3d.Material
 import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute
+import com.badlogic.gdx.graphics.g3d.attributes.FloatAttribute
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute
 import com.mbrlabs.mundus.commons.assets.MaterialAsset
 import com.mbrlabs.mundus.commons.assets.TextureAsset
@@ -184,8 +185,8 @@ class ModelImporter(private val registry: Registry) : SettingsChangedEvent.Setti
             materialAssetToPopulate.roughness = attr.value
         }
 
-        if (materialToUse.has(PBRFloatAttribute.AlphaTest)) {
-            val attr = materialToUse.get(PBRFloatAttribute.AlphaTest) as PBRFloatAttribute
+        if (materialToUse.has(FloatAttribute.AlphaTest)) {
+            val attr = materialToUse.get(FloatAttribute.AlphaTest) as FloatAttribute
             materialAssetToPopulate.alphaTest = attr.value
         }
 


### PR DESCRIPTION
This is the fix for #300 issue and what discussed on discord channel.

1) name field is not set on material

The `name` field is [optional](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-material) and seems some applications don't set it and in this case Mundus throws NullPointerException during gltf import.

2) AlphaTest class cast exception

The [gdx-gltf library uses](https://github.com/mgsx-dev/gdx-gltf/blob/4220b1020bad4c681fff8caf23f27cd152aa115a/gltf/src/net/mgsx/gltf/loaders/shared/material/PBRMaterialLoader.java#L76) `FloatAttribute` for AlphaTest but Mundus tries to cast it to `PBRFloatAttribute` and throws ClassCastException.