### PR TITLE
Get height at world coord at border on triangle fix

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -287,8 +287,8 @@ public class Terrain implements Disposable {
             return 0;
         }
 
-        float xCoord = (terrainX % gridSquareSize) / gridSquareSize;
-        float zCoord = (terrainZ % gridSquareSize) / gridSquareSize;
+        float xCoord = getCoordPercent(terrainX, gridSquareSize);
+        float zCoord = getCoordPercent(terrainZ, gridSquareSize);
 
         c01.set(1, heightData[(gridZ + 1) * vertexResolution + gridX], 0);
         c10.set(0, heightData[gridZ * vertexResolution + gridX + 1], 1);
@@ -528,6 +528,20 @@ public class Terrain implements Disposable {
     public void dispose() {
         model.dispose();
         mesh.dispose();
+    }
+
+    /**
+     * @param terrainPos The x or z terrain position
+     * @param gridSquareSize The grid square size
+     * @return The percent the position in its grid
+     */
+    private float getCoordPercent(final float terrainPos, final float gridSquareSize) {
+        float remaining = terrainPos % gridSquareSize;
+        if (com.badlogic.gdx.math.MathUtils.isEqual(remaining, gridSquareSize)) {
+            remaining = 0f;
+        }
+
+        return remaining / gridSquareSize;
     }
 
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -290,16 +290,16 @@ public class Terrain implements Disposable {
         float xCoord = getCoordPercent(terrainX, gridSquareSize);
         float zCoord = getCoordPercent(terrainZ, gridSquareSize);
 
-        c01.set(1, heightData[(gridZ + 1) * vertexResolution + gridX], 0);
-        c10.set(0, heightData[gridZ * vertexResolution + gridX + 1], 1);
+        c00.set(0, heightData[gridZ * vertexResolution + gridX], 0);
+        c11.set(1, heightData[(gridZ + 1) * vertexResolution + gridX + 1], 1);
+        c10.set(1, heightData[gridZ * vertexResolution + gridX + 1], 0);
 
         float height;
-        if (xCoord <= (1 - zCoord)) { // we are in upper left triangle of the square
-            c00.set(0, heightData[gridZ * vertexResolution + gridX], 0);
-            height = MathUtils.barryCentric(c00, c10, c01, tmpV2.set(zCoord, xCoord));
-        } else { // bottom right triangle
-            c11.set(1, heightData[(gridZ + 1) * vertexResolution + gridX + 1], 1);
-            height = MathUtils.barryCentric(c10, c11, c01, tmpV2.set(zCoord, xCoord));
+        if (MathUtils.isPointOnOrInTriangle(xCoord, zCoord, c00.x, c00.z, c11.x, c11.z, c10.x, c10.z)) { // We are in c00-c11-c10 triangle of square
+            height = MathUtils.barryCentric(c00, c10, c11, tmpV2.set(xCoord, zCoord));
+        } else { // We are in c00-c11-c01 triangle of square
+            c01.set(0, heightData[(gridZ + 1) * vertexResolution + gridX], 1);
+            height = MathUtils.barryCentric(c00, c11, c01, tmpV2.set(xCoord, zCoord));
         }
 
         // Translates to world coordinate

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/Terrain.java
@@ -537,7 +537,7 @@ public class Terrain implements Disposable {
      */
     private float getCoordPercent(final float terrainPos, final float gridSquareSize) {
         float remaining = terrainPos % gridSquareSize;
-        if (com.badlogic.gdx.math.MathUtils.isEqual(remaining, gridSquareSize)) {
+        if (com.badlogic.gdx.math.MathUtils.isEqual(remaining, gridSquareSize, 0.0001f)) {
             remaining = 0f;
         }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/utils/MathUtils.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/utils/MathUtils.java
@@ -16,6 +16,7 @@
 
 package com.mbrlabs.mundus.commons.utils;
 
+import com.badlogic.gdx.math.Intersector;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 
@@ -120,6 +121,16 @@ public class MathUtils {
             // If the projected point lies on the line segment, return the projected point.
             out.set(lineStart).add(projectedPoint);
         }
+    }
+
+    /**
+     * Returns true if the given point is on or inside the triangle.
+     */
+    public static boolean isPointOnOrInTriangle(float px, float py, float ax, float ay, float bx, float by, float cx, float cy) {
+        return com.badlogic.gdx.math.MathUtils.isEqual(Intersector.distanceSegmentPoint(ax, ay, bx, by, px, py), 0.0f) ||
+                com.badlogic.gdx.math.MathUtils.isEqual(Intersector.distanceSegmentPoint(ax, ay, cx, cy, px, py), 0.0f) ||
+                com.badlogic.gdx.math.MathUtils.isEqual(Intersector.distanceSegmentPoint(bx, by, cx, cy, px, py), 0.0f) ||
+                Intersector.isPointInTriangle(px, py, ax, ay, bx, by, cx, cy);
     }
 
 }

--- a/commons/src/test/com/mbrlabs/mundus/commons/terrain/TerrainTest.java
+++ b/commons/src/test/com/mbrlabs/mundus/commons/terrain/TerrainTest.java
@@ -1,0 +1,37 @@
+package com.mbrlabs.mundus.commons.terrain;
+
+import com.badlogic.gdx.math.Matrix4;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TerrainTest {
+
+    @Test
+    public void testGetHeightAtWorldCoordOnC00AndC10Line() {
+        // given
+        final int vertexResolution = 50;
+        final int terrainWidth = 100;
+        // The gridSquareSize is 2.0408163 ((float)terrainWidth / ((float)vertexResolution -1)
+
+        // and
+        final float terrainX = 15.412959f; // The gridX is 7
+        final float terrainZ = 22.448978f; // The gridZ is 11
+
+        // and
+        final float[] heightData = new float[vertexResolution * vertexResolution];
+        heightData[(11 + 1) * vertexResolution + 7] = 5.3379793f; // C01
+        heightData[11 * vertexResolution + 7 + 1] = 4.534852f; // C10
+        heightData[11 * vertexResolution + 7] = 4.63853f; // C00
+        heightData[(11 + 1) * vertexResolution + 7 + 1] = 5.5601234f; // C11
+
+        final Terrain terrain = new Terrain(vertexResolution, heightData);
+        terrain.terrainWidth = terrainWidth;
+
+        // when get height value on C00 - C10 line
+        final float result = terrain.getHeightAtWorldCoord(terrainX, terrainZ, new Matrix4());
+
+        // then the value will be from C00 - C10 line
+        Assert.assertEquals(4.57589f, result, 0.01f);
+    }
+
+}

--- a/commons/src/test/com/mbrlabs/mundus/commons/utils/MathUtilsTest.java
+++ b/commons/src/test/com/mbrlabs/mundus/commons/utils/MathUtilsTest.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Vector3;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MathUtilsTest {
     @Test
@@ -37,6 +38,28 @@ public class MathUtilsTest {
         assertEquals(-0.0175f, roundUp(testVector.y), 0);
         assertEquals(0f, testVector.z, 0);
 
+    }
+
+    @Test
+    public void testIsPointOnOrInTriangle() {
+        final float ax = 0.0f;
+        final float ay = 0.0f;
+        final float bx = 1.0f;
+        final float by = 0.0f;
+        final float cx = 0.0f;
+        final float cy = 1.0f;
+
+        // AB side
+        assertTrue(MathUtils.isPointOnOrInTriangle(0.54f, 0.0f, ax, ay, bx, by, cx, cy));
+
+        // AC side
+        assertTrue(MathUtils.isPointOnOrInTriangle(0.0f, 0.54f, ax, ay, bx, by, cx, cy));
+
+        // BC side
+        assertTrue(MathUtils.isPointOnOrInTriangle(0.5f, 0.5f, ax, ay, bx, by, cx, cy));
+
+        // Inside triangle
+        assertTrue(MathUtils.isPointOnOrInTriangle(0.2f, 0.2f, ax, ay, bx, by, cx, cy));
     }
 
     private float roundUp(float value) {


### PR DESCRIPTION
The `getHeightAtWorldCoord` method from Terrain class returns with wrong height value if near to the border of triangle.

With an example: if this represents the grid matrix:
```
C11-----------C01
 |           /  |
 |         /    |
 |      /       |
 |   /          |
 | /            |
C10-----------C00
```

Then if want to get the height value on C10-C00 line then will return the height value from C11-C01 line. The root cause is the modulo calculation with float number.

Add a unit test to check the problem.