### PR TITLE
Update mockito to 4.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
         visuiVersion = '1.5.5'
         kryoVersion = '5.2.0'
         junitVersion = '4.13.2'
-        mockitoVersion = '1.10.19'
+        mockitoVersion = '4.11.0'
         commonsIoVersion = '2.5'
         commonsLangVersion = '3.12.0'
         gltfVersion = '2.2.1'
@@ -60,7 +60,7 @@ project(":commons") {
 
         testImplementation "junit:junit:$junitVersion"
 
-        testImplementation "org.mockito:mockito-all:$mockitoVersion"
+        testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
     }
 }
@@ -118,7 +118,7 @@ project(":editor") {
 
         // tests
         testImplementation "junit:junit:$junitVersion"
-        testImplementation "org.mockito:mockito-all:$mockitoVersion"
+        testImplementation "org.mockito:mockito-core:$mockitoVersion"
     }
 }
 


### PR DESCRIPTION
The Mundus can not build with jdk >= 17 because there is this error:

```java
Caused by:
java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @76552cb
    at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
    at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
    at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
    at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
    at org.mockito.cglib.core.ReflectUtils$2.run(ReflectUtils.java:57)
    at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
    at org.mockito.cglib.core.ReflectUtils.<clinit>(ReflectUtils.java:47)
    ... 17 more
```

The mockito upgrade resolves this issue. With this fix the project can build with jdk 17 and jdk 21.

Without this fix, can run with jdk 21, but should build with jdk8.