### PR TITLE
Terrain normals stitching

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/PlaneMesh.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/PlaneMesh.java
@@ -249,6 +249,73 @@ public class PlaneMesh implements Disposable {
         }
     }
 
+    public boolean stitchEdgeNormalsFromNeighbors(PlaneMesh north, PlaneMesh east, PlaneMesh south, PlaneMesh west, Pool<Vector3> pool) {
+        int res = vertexResolution;
+        boolean changed = false;
+
+        if (north != null) {
+            changed |= stitchEdge(north, 0, res - 1, res - 1, res - 1, 0, 0, pool);
+        }
+
+        // Bottom edge (y = 0)
+        if (south != null) {
+            changed |= stitchEdge(south, 0, 0, res - 1, 0, 0, res - 1, pool);
+        }
+
+        // Left edge (x = 0)
+        if (west != null) {
+            changed |= stitchEdge(west, 0, 0, 0, res - 1, res - 1, 0, pool);
+        }
+
+        // Right edge (x = res-1)
+        if (east != null) {
+            changed |= stitchEdge(east, res - 1, 0, res - 1, res - 1, 0, 0, pool);
+        }
+
+        if (changed) {
+            computeTangents();
+            updateMeshVertices();
+        }
+
+        return changed;
+    }
+
+    private boolean stitchEdge(PlaneMesh neighbor, int startX, int startY, int endX, int endY, int neighborStartX, int neighborStartY, Pool<Vector3> pool) {
+        if (neighbor == null) return false;
+
+        boolean changed = false;
+        Vector3 n1 = pool.obtain();
+        Vector3 n2 = pool.obtain();
+        Vector3 originalNormal = pool.obtain();
+
+        for (int i = 0; i < vertexResolution; i++) {
+            int x = startX == endX ? startX : i;
+            int y = startY == endY ? startY : i;
+            int nx = startX == endX ? neighborStartX : i;
+            int ny = startY == endY ? neighborStartY : i;
+
+            getNormalAt(n1, x, y);
+            neighbor.getNormalAt(n2, nx, ny);
+            originalNormal.set(n1);
+            n1.add(n2).nor();
+
+            if (!n1.epsilonEquals(originalNormal, 0.001f)) {
+                changed = true;
+                setNormalAt(x, y, n1);
+            }
+        }
+
+        pool.free(n1);
+        pool.free(n2);
+        pool.free(originalNormal);
+
+        if (changed) {
+            neighbor.computeTangents();
+            neighbor.updateMeshVertices();
+        }
+
+        return changed;
+    }
 
     /**
      * Retrieve the vertex x,y,z position from the vertices array for the given vertex index.
@@ -256,6 +323,11 @@ public class PlaneMesh implements Disposable {
     private void getVertexPos(Vector3 out, int index) {
         int start = index * stride;
         out.set(vertices[start + posPos], vertices[start + posPos + 1], vertices[start + posPos + 2]);
+    }
+
+    public void setNormalAt(int x, int z, Vector3 normal) {
+        int vertexIndex = z * vertexResolution + x;
+        setVertexNormal(vertexIndex, normal);
     }
 
     /**
@@ -330,7 +402,6 @@ public class PlaneMesh implements Disposable {
         int start = vertexIndex * stride;
         return out.set(vertices[start + norPos], vertices[start + norPos + 1], vertices[start + norPos + 2]);
     }
-
 
     public float[] getVertices() {
         return vertices;

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/PlaneMesh.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/PlaneMesh.java
@@ -302,6 +302,7 @@ public class PlaneMesh implements Disposable {
             if (!n1.epsilonEquals(originalNormal, 0.001f)) {
                 changed = true;
                 setNormalAt(x, y, n1);
+                neighbor.setNormalAt(nx, ny, n1);
             }
         }
 

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainStitcher.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainStitcher.java
@@ -25,7 +25,7 @@ public class TerrainStitcher {
     /** Float comparison threshold */
     private static final float threshold = 0.001f;
 
-    public static boolean stitch(Array<TerrainComponent> terrainComponents, Pool<Vector3> pool) {
+    public static boolean stitch(Array<TerrainComponent> terrainComponents) {
         int heightsStitched = 0;
         for (TerrainComponent terrainComponent : terrainComponents) {
             heightsStitched = stitchTopBottomNeighbors(terrainComponent);

--- a/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainStitcher.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/terrain/TerrainStitcher.java
@@ -1,17 +1,11 @@
-package com.mbrlabs.mundus.editor.terrain;
+package com.mbrlabs.mundus.commons.terrain;
 
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
-import com.mbrlabs.mundus.commons.scene3d.GameObject;
-import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.badlogic.gdx.utils.Pool;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.utils.Pools;
-import com.mbrlabs.mundus.editor.Mundus;
-import com.mbrlabs.mundus.editor.core.project.ProjectContext;
-import com.mbrlabs.mundus.editorcommons.events.TerrainVerticesChangedEvent;
-import com.mbrlabs.mundus.editor.history.commands.TerrainStitchCommand;
-import com.mbrlabs.mundus.editor.ui.UI;
 
 /**
  * Utility class to stitch all terrains within a scene together based on their neighbors.
@@ -31,68 +25,35 @@ public class TerrainStitcher {
     /** Float comparison threshold */
     private static final float threshold = 0.001f;
 
-    public static void stitch(ProjectContext projectContext) {
-        // Get all the terrain components
-        Array<GameObject> terrainGOs = projectContext.currScene.sceneGraph.findAllByComponent(Component.Type.TERRAIN);
-        Array<TerrainComponent> terrainComponents = new Array<>();
-
-        for (GameObject go : terrainGOs) {
-            TerrainComponent terrainComponent = (TerrainComponent) go.findComponentByType(Component.Type.TERRAIN);
-
-            int length = terrainComponent.getTerrainAsset().getTerrain().vertexResolution;
-            if (numSteps > length) {
-                throw new IllegalArgumentException("Number of Steps must be less than the vertex resolution of the terrain (" + length + ")");
-            }
-
-            terrainComponents.add(terrainComponent);
-        }
-
-        // Add command for undo/redo history
-        TerrainStitchCommand command = new TerrainStitchCommand(terrainComponents);
-
-        // Stitch them together
-        int heightsStitched = stitch(terrainComponents);
-
-        if (heightsStitched == 0) {
-            // No changes were made, so don't add to history
-            return;
-        }
-
-        // Execute command/apply changes to terrains
-        Mundus.INSTANCE.getCommandHistory().add(command);
-        command.setHeightDataAfter();
-        command.execute();
-
-        // Now add to the modified assets so they can be saved
-        for (TerrainComponent terrainComponent : terrainComponents) {
-            projectContext.assetManager.addModifiedAsset(terrainComponent.getTerrainAsset());
-            Mundus.INSTANCE.postEvent(new TerrainVerticesChangedEvent(terrainComponent));
-        }
-    }
-
-    public static int stitch(Array<TerrainComponent> terrainComponents) {
-        int neighbors = 0;
+    public static boolean stitch(Array<TerrainComponent> terrainComponents, Pool<Vector3> pool) {
         int heightsStitched = 0;
         for (TerrainComponent terrainComponent : terrainComponents) {
             heightsStitched = stitchTopBottomNeighbors(terrainComponent);
-            if (terrainComponent.getTopNeighbor() != null) neighbors++;
-            if (terrainComponent.getBottomNeighbor() != null) neighbors++;
         }
 
         for (TerrainComponent terrainComponent : terrainComponents) {
             heightsStitched += stitchLeftRightNeighbors(terrainComponent);
-            if (terrainComponent.getLeftNeighbor() != null) neighbors++;
-            if (terrainComponent.getRightNeighbor() != null) neighbors++;
         }
 
-        if (neighbors == 0) {
-            UI.INSTANCE.getToaster().error("No terrains had neighbors assigned.");
-        } else if (heightsStitched == 0) {
-            UI.INSTANCE.getToaster().info("No terrains needed stitching.");
-        } else {
-            UI.INSTANCE.getToaster().success("Stitched " + heightsStitched + " height values.");
-        }
-        return heightsStitched;
+        return heightsStitched > 0;
+    }
+
+    /**
+     * Used as a post-processing step for terrains with neighbors. Smooths the normals along the edges of the terrain
+     * to prevent visible seams between neighboring terrains.
+     * Because terrains are stored as heightmaps, this must be done at runtime once all neighbors are loaded.
+     * @return true if any normals were stitched, false if all normals were already seamless
+     */
+    public static boolean stitchNormals(TerrainComponent tc, Pool<Vector3> pool)
+    {
+        PlaneMesh top = tc.getTopNeighbor() != null ? tc.getTopNeighbor().getTerrainAsset().getTerrain().getPlaneMesh() : null;
+        PlaneMesh left = tc.getLeftNeighbor() != null ? tc.getLeftNeighbor().getTerrainAsset().getTerrain().getPlaneMesh() : null;
+        PlaneMesh bottom = tc.getBottomNeighbor() != null ? tc.getBottomNeighbor().getTerrainAsset().getTerrain().getPlaneMesh() : null;
+        PlaneMesh right = tc.getRightNeighbor() != null ? tc.getRightNeighbor().getTerrainAsset().getTerrain().getPlaneMesh() : null;
+
+        PlaneMesh mesh = tc.getTerrainAsset().getTerrain().getPlaneMesh();
+
+        return mesh.stitchEdgeNormalsFromNeighbors(top, left, bottom, right, pool);
     }
 
     private static int stitchTopBottomNeighbors(TerrainComponent terrainComponent) {

--- a/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/core/converter/GameObjectConverter.java
@@ -34,10 +34,12 @@ import com.mbrlabs.mundus.commons.scene3d.components.CustomPropertiesComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.LightComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainManagerComponent;
+import com.mbrlabs.mundus.commons.terrain.TerrainStitcher;
 import com.mbrlabs.mundus.commons.utils.AssetUtils;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableModelComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableTerrainComponent;
 import com.mbrlabs.mundus.editor.scene3d.components.PickableWaterComponent;
+import com.mbrlabs.mundus.editor.utils.ThreadLocalPools;
 
 import java.util.Map;
 
@@ -174,6 +176,9 @@ public class GameObjectConverter {
                         terrainComponent.setLeftNeighbor((TerrainComponent) leftNeighbor.findComponentByType(Component.Type.TERRAIN));
                     }
                 }
+
+                // We have to wait until all neighbors are set before stitching
+                TerrainStitcher.stitchNormals(terrainComponent, ThreadLocalPools.vector3ThreadPool.get());
             }
         }
     }

--- a/editor/src/main/com/mbrlabs/mundus/editor/terrain/EditorTerrainStitcher.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/terrain/EditorTerrainStitcher.java
@@ -66,7 +66,7 @@ public class EditorTerrainStitcher extends TerrainStitcher {
     }
 
     public static boolean stitchComponent(Array<TerrainComponent> terrainComponents) {
-        boolean updates = stitch(terrainComponents, ThreadLocalPools.vector3ThreadPool.get());
+        boolean updates = stitch(terrainComponents);
 
         if (updates) {
             UI.INSTANCE.getToaster().success("Terrain stitcher finished updates");

--- a/editor/src/main/com/mbrlabs/mundus/editor/terrain/EditorTerrainStitcher.java
+++ b/editor/src/main/com/mbrlabs/mundus/editor/terrain/EditorTerrainStitcher.java
@@ -1,0 +1,80 @@
+package com.mbrlabs.mundus.editor.terrain;
+
+import com.badlogic.gdx.utils.Array;
+import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
+import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
+import com.mbrlabs.mundus.commons.terrain.TerrainStitcher;
+import com.mbrlabs.mundus.editor.Mundus;
+import com.mbrlabs.mundus.editor.core.project.ProjectContext;
+import com.mbrlabs.mundus.editor.history.commands.TerrainStitchCommand;
+import com.mbrlabs.mundus.editor.ui.UI;
+import com.mbrlabs.mundus.editor.utils.ThreadLocalPools;
+import com.mbrlabs.mundus.editorcommons.events.TerrainVerticesChangedEvent;
+
+/**
+ * Editor extension of the TerrainStitcher utility class.
+ * Finds all terrain components in the current scene and stitches them together based on their neighbors.
+ * Also adds the changes to the undo/redo history and marks the terrain assets as modified so they can be saved.
+ * @author JamesTKhan
+ * @version May 16, 2026
+ */
+public class EditorTerrainStitcher extends TerrainStitcher {
+
+    public static void stitch(ProjectContext projectContext) {
+        // Get all the terrain components
+        Array<GameObject> terrainGOs = projectContext.currScene.sceneGraph.findAllByComponent(Component.Type.TERRAIN);
+        Array<TerrainComponent> terrainComponents = new Array<>();
+
+        for (GameObject go : terrainGOs) {
+            TerrainComponent terrainComponent = go.findComponentByType(Component.Type.TERRAIN);
+
+            int length = terrainComponent.getTerrainAsset().getTerrain().vertexResolution;
+            if (numSteps > length) {
+                throw new IllegalArgumentException("Number of Steps must be less than the vertex resolution of the terrain (" + length + ")");
+            }
+
+            terrainComponents.add(terrainComponent);
+        }
+
+        // Add command for undo/redo history
+        TerrainStitchCommand command = new TerrainStitchCommand(terrainComponents);
+
+        // Stitch them together
+        boolean terrainUpdated = stitchComponent(terrainComponents);
+
+        if (!terrainUpdated) {
+            // No changes were made, so don't add to history
+            return;
+        }
+
+        // Execute command/apply changes to terrains
+        Mundus.INSTANCE.getCommandHistory().add(command);
+        command.setHeightDataAfter();
+        command.execute();
+
+        // Now add to the modified assets so they can be saved
+        for (TerrainComponent terrainComponent : terrainComponents) {
+            projectContext.assetManager.addModifiedAsset(terrainComponent.getTerrainAsset());
+            Mundus.INSTANCE.postEvent(new TerrainVerticesChangedEvent(terrainComponent));
+        }
+
+        // Post process normals after stitching heights
+        for (TerrainComponent terrainComponent : terrainComponents) {
+            stitchNormals(terrainComponent, ThreadLocalPools.vector3ThreadPool.get());
+        }
+    }
+
+    public static boolean stitchComponent(Array<TerrainComponent> terrainComponents) {
+        boolean updates = stitch(terrainComponents, ThreadLocalPools.vector3ThreadPool.get());
+
+        if (updates) {
+            UI.INSTANCE.getToaster().success("Terrain stitcher finished updates");
+        } else {
+            UI.INSTANCE.getToaster().info("Terrain stitcher finished, no updates needed");
+        }
+
+        return updates;
+    }
+
+}

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainChunksDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/AddTerrainChunksDialog.kt
@@ -30,6 +30,7 @@ import com.mbrlabs.mundus.editor.core.io.IOManagerProvider
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
 import com.mbrlabs.mundus.editor.events.AssetImportEvent
 import com.mbrlabs.mundus.editor.events.SceneGraphChangedEvent
+import com.mbrlabs.mundus.editor.terrain.EditorTerrainStitcher
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.terrain.HeightMapTerrainTab
 import com.mbrlabs.mundus.editor.ui.modules.dialogs.terrain.ProceduralTerrainTab
@@ -38,6 +39,7 @@ import com.mbrlabs.mundus.editor.utils.ThreadLocalPools
 import com.mbrlabs.mundus.editor.utils.createTerrainGO
 import com.mbrlabs.mundus.editorcommons.exceptions.AssetAlreadyExistsException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
@@ -94,6 +96,9 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
     private var executor: ExecutorService? = null
     private var terraformExecutor: ExecutorService? = null
 
+    private val lodTasks: ConcurrentLinkedQueue<TerrainComponent> = ConcurrentLinkedQueue()
+    private var lodExecutor: ExecutorService? = null
+
     override fun draw(batch: Batch?, parentAlpha: Float) {
         val assetsToCreate = assetsToCreate.size > 0
 
@@ -115,7 +120,7 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
                     + "Terraform Queue: ${assetsToTerraform.size}\n")
 
             loadingDialog!!.pack()
-            if (!assetsToCreate && creationThreads.get() == 0 && assetsToTerraform.isEmpty()) {
+            if (!assetsToCreate && creationThreads.get() == 0 && assetsToTerraform.isEmpty() && lodTasks.isEmpty()) {
                 generatingTerrain = false
                 color.a = 1.0f
                 loadingDialog?.hide()
@@ -331,15 +336,10 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
         terraformExecutor?.submit {
             terraformingThreads.addAndGet(1)
 
-            var minHeight = 0f
-            var maxHeight = 0f
+
             if (tabbedPane.activeTab is ProceduralTerrainTab) {
-                minHeight = proceduralTerrainTab.getMinHeightValue()
-                maxHeight = proceduralTerrainTab.getMaxHeightValue()
                 proceduralTerrainTab.terraform(grid.x.toInt(), grid.y.toInt(), component)
             } else if (tabbedPane.activeTab is HeightMapTerrainTab) {
-                minHeight = heightmapTerrainTab.getMinHeightValue()
-                maxHeight = heightmapTerrainTab.getMaxHeightValue()
                 heightmapTerrainTab.terraform(grid.x.toInt(), grid.y.toInt(), component)
             }
 
@@ -350,16 +350,38 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
             Gdx.app.postRunnable {
                 component.updateDimensions()
 
-                if (generateLoD) {
-                    // Generate simplified results for LoD
-                    val results = LoDUtils.buildTerrainLod(component, Terrain.LOD_SIMPLIFICATION_FACTORS, abs(maxHeight - minHeight))
-
-                    // Convert to LodLevels with actual meshes
-                    asset.lodLevels = LoDUtils.convertToLodLevels(asset.terrain.model, results)
-                }
-
+                lodTasks.add(component)
                 terraformingThreads.decrementAndGet()
+
+                // Once all threads are done and queue is empty, start LoD generation
+                if (terraformingThreads.get() == 0 && assetsToTerraform.isEmpty()) {
+                    startLodAndStitching()
+                }
             }
+        }
+    }
+
+    /**
+     * Handles stitching normals with neighbors and generating LoD levels if needed
+     */
+    private fun startLodAndStitching() {
+        lodExecutor = Executors.newSingleThreadExecutor()
+        lodExecutor?.submit {
+            while (!lodTasks.isEmpty()) {
+                val component = lodTasks.poll()
+                if (component != null) {
+                    EditorTerrainStitcher.stitchNormals(component, ThreadLocalPools.vector3ThreadPool.get())
+
+                    if (generateLoD) {
+                        Gdx.app.postRunnable {
+                            // We cannot generate LoD levels off the rendering thread because it involves mesh creation
+                            CreateLods(component)
+                        }
+                    }
+                }
+            }
+            lodExecutor?.shutdown()
+            lodExecutor = null
         }
     }
 
@@ -371,6 +393,25 @@ class AddTerrainChunksDialog : BaseDialog("Add Terrain"), TabbedPaneListener {
                 terrainAssetName, resolution, width, splatMapResolution)
 
         return asset
+    }
+
+    private fun CreateLods(terrainComponent: TerrainComponent)
+    {
+        var minHeight = 0f
+        var maxHeight = 0f
+        if (tabbedPane.activeTab is ProceduralTerrainTab) {
+            minHeight = proceduralTerrainTab.getMinHeightValue()
+            maxHeight = proceduralTerrainTab.getMaxHeightValue()
+        } else if (tabbedPane.activeTab is HeightMapTerrainTab) {
+            minHeight = heightmapTerrainTab.getMinHeightValue()
+            maxHeight = heightmapTerrainTab.getMaxHeightValue()
+        }
+
+        // Generate simplified results for LoD
+        val results = LoDUtils.buildTerrainLod(terrainComponent, Terrain.LOD_SIMPLIFICATION_FACTORS, abs(maxHeight - minHeight))
+        val asset = terrainComponent?.terrainAsset
+        // Convert to LodLevels with actual meshes
+        asset?.lodLevels = LoDUtils.convertToLodLevels(asset?.terrain?.model, results)
     }
 
     /**

--- a/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/TerrainStitcherDialog.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/ui/modules/dialogs/TerrainStitcherDialog.kt
@@ -12,7 +12,7 @@ import com.kotcrab.vis.ui.widget.VisTable
 import com.kotcrab.vis.ui.widget.VisTextButton
 import com.mbrlabs.mundus.editor.Mundus
 import com.mbrlabs.mundus.editor.core.project.ProjectManager
-import com.mbrlabs.mundus.editor.terrain.TerrainStitcher
+import com.mbrlabs.mundus.editor.terrain.EditorTerrainStitcher
 import com.mbrlabs.mundus.editor.ui.UI
 import com.mbrlabs.mundus.editor.ui.widgets.IntegerFieldWithLabel
 import com.mbrlabs.mundus.editor.ui.widgets.ToolTipLabel
@@ -39,7 +39,7 @@ class TerrainStitcherDialog : BaseDialog(TITLE) {
     }
 
     private fun setupUI() {
-        numStepsField.text = TerrainStitcher.numSteps.toString()
+        numStepsField.text = EditorTerrainStitcher.numSteps.toString()
 
         val table = VisTable()
 
@@ -62,8 +62,8 @@ class TerrainStitcherDialog : BaseDialog(TITLE) {
     }
 
     override fun show(stage: Stage?, action: Action?): VisDialog {
-        numStepsField.text = TerrainStitcher.numSteps.toString()
-        includeWorldHeight.isChecked = TerrainStitcher.includeWorldHeight
+        numStepsField.text = EditorTerrainStitcher.numSteps.toString()
+        includeWorldHeight.isChecked = EditorTerrainStitcher.includeWorldHeight
         return super.show(stage, action)
     }
 
@@ -72,14 +72,14 @@ class TerrainStitcherDialog : BaseDialog(TITLE) {
     private fun setupListeners() {
         numStepsField.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent?, actor: Actor?) {
-                TerrainStitcher.numSteps = numStepsField.int
+                EditorTerrainStitcher.numSteps = numStepsField.int
             }
         })
 
         executeBtn.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
                 try {
-                    TerrainStitcher.stitch(projectManager.current())
+                    EditorTerrainStitcher.stitch(projectManager.current())
                 } catch (e: Exception) {
                     Dialogs.showErrorDialog(UI, e.message)
                 }
@@ -88,7 +88,7 @@ class TerrainStitcherDialog : BaseDialog(TITLE) {
 
         includeWorldHeight.addListener(object : ChangeListener() {
             override fun changed(event: ChangeEvent, actor: Actor) {
-                TerrainStitcher.includeWorldHeight = includeWorldHeight.isChecked
+                EditorTerrainStitcher.includeWorldHeight = includeWorldHeight.isChecked
             }
         })
     }

--- a/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
+++ b/gdx-runtime/src/com/mbrlabs/mundus/runtime/converter/GameObjectConverter.java
@@ -29,6 +29,8 @@ import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
 import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.scene3d.components.TerrainComponent;
+import com.mbrlabs.mundus.commons.terrain.TerrainStitcher;
+import com.mbrlabs.mundus.commons.utils.Pools;
 import com.mbrlabs.mundus.runtime.Shaders;
 import com.mbrlabs.mundus.commons.utils.AssetUtils;
 
@@ -149,6 +151,9 @@ public class GameObjectConverter {
                     final GameObject leftNeighbor = go.findChildById(leftNeighborId);
                     terrainComponent.setLeftNeighbor((TerrainComponent) leftNeighbor.findComponentByType(Component.Type.TERRAIN));
                 }
+
+                // We have to wait until all neighbors are set before stitching
+                TerrainStitcher.stitchNormals(terrainComponent, Pools.vector3Pool);
             }
         }
     }


### PR DESCRIPTION
Connected terrains have visible lighting seams at boundaries. Terrain normal calculations are done at the individual terrain level due to their original design in Mundus, so they do not take neighbors normals into account. The solution for now is to perform a "post-process" like step to match normals of connected terrains at their edges. This is not a perfect solution but does help considerably. Seams at LoD thresholds will still be visible but reduced.

An ideal solution would be to consider neighboring terrains when calculating normals for each terrain but this would require much more changes.

I split existing TerrainStitcher into two, moving core functionality into common and editor specific as an extension. 

Before:
<img width="1088" height="722" alt="without" src="https://github.com/user-attachments/assets/39fda920-6be5-4309-a0a2-9a1c4a4dc39f" />

After:
<img width="1082" height="719" alt="with" src="https://github.com/user-attachments/assets/b53f6ad0-b4ca-4733-9126-21f03a3e3937" />
