### PR TITLE
Fix gltf import if texture is in subdirectory

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -29,6 +29,7 @@
 - Update gdx-gltf version to 2.2.1
 - Fix gltf import when material has not name field
 - Fix gltf import when has alpha material attribute
+- Fix gltf import when texture is in subdirectory
 - Configurable shortcuts
 - Fix Terrain Cloning, now works as expected
 - Added optional ignore filter to GameObjectPicker

--- a/editor/src/main/com/mbrlabs/mundus/editor/assets/FileHandleWithDependencies.kt
+++ b/editor/src/main/com/mbrlabs/mundus/editor/assets/FileHandleWithDependencies.kt
@@ -31,7 +31,9 @@ import java.io.UnsupportedEncodingException
 import java.nio.charset.Charset
 
 
-class FileHandleWithDependencies(val file: FileHandle, val dependencies: ArrayList<FileHandle> = ArrayList()) {
+class FileHandleWithDependencies(val file: FileHandle,
+                                 val dependencies: ArrayList<FileHandle> = ArrayList(),
+                                 private val json: Json = Mundus.inject()) {
     // Holds all the images parsed from the GLTF file,
     var images = Array<FileHandle>()
 
@@ -52,11 +54,13 @@ class FileHandleWithDependencies(val file: FileHandle, val dependencies: ArrayLi
         file.copyTo(dest)
 
         dependencies.forEach { it.copyTo(dest) }
+
+        if (FileFormatUtils.isGLTF(file)) {
+            updateGLTFFileIfHasDependencies(dest)
+        }
     }
 
     private fun loadGLTFDependencies() {
-        val json = Mundus.inject<Json>()
-
         val dto = json.fromJson(GLTF::class.java, file)
 
         dto.materials?.filter { it.name != null }?.forEach {
@@ -140,5 +144,25 @@ class FileHandleWithDependencies(val file: FileHandle, val dependencies: ArrayLi
 
         // Assign the given attribute with the image index
         map[attribute] = imageIndex
+    }
+
+    /**
+     * Updates GLTF image uri to same directory with gltf file.
+     */
+    private fun updateGLTFFileIfHasDependencies(dest: FileHandle) {
+        // Move imaged from subdirectories to the root directory
+        val copiedFile = dest.child(file.name())
+
+        val dto = json.fromJson(GLTF::class.java, copiedFile)
+        var changed = false
+        dto.images?.forEach { it ->
+            if (it.uri.contains("/")) {
+                it.uri = it.uri.substringAfter("/")
+                changed = true
+            }
+        }
+        if (changed) {
+            json.toJson(dto, copiedFile)
+        }
     }
 }

--- a/editor/src/test/kotlin/com/mbrlabs/mundus/editor/assets/FileHandleWithDependenciesTest.kt
+++ b/editor/src/test/kotlin/com/mbrlabs/mundus/editor/assets/FileHandleWithDependenciesTest.kt
@@ -1,0 +1,176 @@
+package com.mbrlabs.mundus.editor.assets
+
+import com.badlogic.gdx.files.FileHandle
+import com.badlogic.gdx.utils.Array
+import com.badlogic.gdx.utils.Json
+import net.mgsx.gltf.data.GLTF
+import net.mgsx.gltf.data.data.GLTFBuffer
+import net.mgsx.gltf.data.texture.GLTFImage
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito
+
+class FileHandleWithDependenciesTest {
+
+    @Test
+    fun `Test copyTo method with non GLTF file`() {
+        // given: the file
+        val fileName = "model.g3db"
+        val file = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(file.name()).thenReturn(fileName)
+
+        // and: the json parser
+        val json = Mockito.mock(Json::class.java)
+
+        // and: the destination directory
+        val destination = Mockito.mock(FileHandle::class.java)
+
+        // and: the testable object
+        val tested = FileHandleWithDependencies(file, json = json)
+
+        // when: the 'copyTo' method called
+        tested.copyTo(destination)
+
+        // then: 'copyTo' method called on the file to the destination file
+        Mockito.verify(file).copyTo(destination)
+
+        // and: json parser has not used
+        Mockito.verify(json, Mockito.never()).fromJson(Mockito.eq(GLTF::class.java), Mockito.any(FileHandle::class.java))
+    }
+
+    @Test
+    fun `Test copyTo method with GLTF file without dependencies`() {
+        // given: the file with path
+        val path = "/tmp/"
+        val fileName = "model.gltf"
+        val file = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(file.name()).thenReturn(fileName)
+
+        // and: parent directory
+        val parent = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(parent.path()).thenReturn(path)
+        Mockito.`when`(file.parent()).thenReturn(parent)
+
+        // and: parsed GLTF file
+        val gltf = GLTF()
+        val gltfBuffer = GLTFBuffer()
+        gltf.buffers = Array()
+        gltf.buffers.add(gltfBuffer)
+
+        // and: the json parser
+        val json = Mockito.mock(Json::class.java)
+        Mockito.`when`(json.fromJson(Mockito.eq(GLTF::class.java), Mockito.any(FileHandle::class.java))).thenReturn(gltf)
+
+        // and: the copied file and destination directory
+        val copiedFile = Mockito.mock(FileHandle::class.java)
+        val destination = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(destination.child(fileName)).thenReturn(copiedFile)
+
+        // and: the testable object
+        val tested = FileHandleWithDependencies(file, json = json)
+
+        // when: the 'copyTo' method called
+        tested.copyTo(destination)
+
+        // then: 'copyTo' method called on the file to the destination file
+        Mockito.verify(file).copyTo(destination)
+
+        // and: gltf file has not updated
+        Mockito.verify(json, Mockito.never()).toJson(gltf, copiedFile)
+    }
+
+    @Test
+    fun `Test copyTo method with GLTF file with image dependency in same directory`() {
+        // given: the file with path
+        val path = "/tmp/"
+        val fileName = "model.gltf"
+        val file = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(file.name()).thenReturn(fileName)
+
+        // and: parent directory
+        val parent = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(parent.path()).thenReturn(path)
+        Mockito.`when`(file.parent()).thenReturn(parent)
+
+        // and: parsed GLTF file
+        val gltf = GLTF()
+        val gltfBuffer = GLTFBuffer()
+        val gltfImage = GLTFImage()
+        gltfImage.uri = "texture.png"
+
+        gltf.buffers = Array()
+        gltf.buffers.add(gltfBuffer)
+        gltf.images = Array()
+        gltf.images.add(gltfImage)
+
+        // and: the json parser
+        val json = Mockito.mock(Json::class.java)
+        Mockito.`when`(json.fromJson(Mockito.eq(GLTF::class.java), Mockito.any(FileHandle::class.java))).thenReturn(gltf)
+
+        // and: the copied file and destination directory
+        val copiedFile = Mockito.mock(FileHandle::class.java)
+        val destination = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(destination.child(fileName)).thenReturn(copiedFile)
+
+        // and: the testable object
+        val tested = FileHandleWithDependencies(file, json = json)
+
+        // when: the 'copyTo' method called
+        tested.copyTo(destination)
+
+        // then: 'copyTo' method called on the file to the destination file
+        Mockito.verify(file).copyTo(destination)
+
+        // and: gltf file has been not updated
+        Mockito.verify(json, Mockito.never()).toJson(gltf, copiedFile)
+    }
+
+    @Test
+    fun `Test copyTo method with GLTF file with image dependency in subdirectory`() {
+        // given: the file with path
+        val path = "/tmp/"
+        val fileName = "model.gltf"
+        val file = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(file.name()).thenReturn(fileName)
+
+        // and: parent directory
+        val parent = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(parent.path()).thenReturn(path)
+        Mockito.`when`(file.parent()).thenReturn(parent)
+
+        // and: parsed GLTF file
+        val gltf = GLTF()
+        val gltfBuffer = GLTFBuffer()
+        val gltfImage = GLTFImage()
+        gltfImage.uri = "textures/texture.png"
+
+        gltf.buffers = Array()
+        gltf.buffers.add(gltfBuffer)
+        gltf.images = Array()
+        gltf.images.add(gltfImage)
+
+        // and: the json parser
+        val json = Mockito.mock(Json::class.java)
+        Mockito.`when`(json.fromJson(Mockito.eq(GLTF::class.java), Mockito.any(FileHandle::class.java))).thenReturn(gltf)
+
+        // and: the copied file and destination directory
+        val copiedFile = Mockito.mock(FileHandle::class.java)
+        val destination = Mockito.mock(FileHandle::class.java)
+        Mockito.`when`(destination.child(fileName)).thenReturn(copiedFile)
+
+        // and: the testable object
+        val tested = FileHandleWithDependencies(file, json = json)
+
+        // when: the 'copyTo' method called
+        tested.copyTo(destination)
+
+        // then: 'copyTo' method called on the file to the destination file
+        Mockito.verify(file).copyTo(destination)
+
+        // and: gltf file has been updated
+        Mockito.verify(json).toJson(gltf, copiedFile)
+
+        // and: the uri of image has been updated to the same directory with gltf file
+        Assert.assertEquals("texture.png", gltfImage.uri)
+    }
+}


### PR DESCRIPTION
Hi,

I wanted to load [this GLTF file](http://github.com/MonstrousSoftware/CascadedShadows/tree/master/assets/models) to test something but I got an error.  

The problem: Mundus editor copies the gltf file into the `.mundus/temp/.../` directory with dependencies, but dependencies will be next to the gltf file. So this fix updates image uri path in gltf file if dependencies were in a subdirectory.